### PR TITLE
add context support

### DIFF
--- a/executil/run.go
+++ b/executil/run.go
@@ -1,0 +1,44 @@
+package executil
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// Run starts the specified command and waits for it to complete.
+//
+// The difference to Run from exec.CommandContext is that it sends an interrupt
+// instead of a kill, which gives the process time for a graceful shutdown.
+func Run(ctx context.Context, cmd *exec.Cmd) error {
+	commandline := strings.Join(cmd.Args, " ")
+	logrus.WithFields(logrus.Fields{
+		"Args": cmd.Args,
+		"Dir":  cmd.Dir,
+	}).Debugf("running command `%s`", commandline)
+
+	err := cmd.Start()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	done := make(chan struct{}, 1)
+	defer close(done)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			logrus.Debugf("sending interrupt signal to `%s`", commandline)
+			cmd.Process.Signal(syscall.SIGINT)
+		case <-done:
+			// This mean wait() already exited and we can stop to wait for the
+			// cancelation.
+		}
+	}()
+
+	return errors.Wrapf(cmd.Wait(), "failed to run `%s`", commandline)
+}


### PR DESCRIPTION
This consists of two parts, that were already used by `regrant`:

* It improves the `cmdutil` application, so it provides a Run function that gets a context. This mean that application, that use `cmdutil` get a root context.
* It adds a helper for `exec` that runs an application with an context. If this context gets cancelled, the command get a graceful shutdown signal.