### PR TITLE
fix wrapper and version command description

### DIFF
--- a/v2/cmd/buildutil/generator.go
+++ b/v2/cmd/buildutil/generator.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	templateWrapper = `#!/bin/sh
+	templateWrapper = `#!/bin/bash
 
 set -euo pipefail
 

--- a/v2/cmd/buildutil/test-fixtures/buildutilw-golden.sh
+++ b/v2/cmd/buildutil/test-fixtures/buildutilw-golden.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 

--- a/v2/pkg/cmdutil/version.go
+++ b/v2/pkg/cmdutil/version.go
@@ -24,7 +24,7 @@ var (
 func NewVersionCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "version",
-		Short:             "shows version of this application",
+		Short:             "Shows version of this application",
 		PersistentPreRun:  func(cmd *cobra.Command, args []string) {},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {},
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
* Fix buildutil wrapper, because `set -o pipefail` is a bash feature
* Streamline version command description, because the description of the Cobra `help` command also starts with an uppercase letter.