### PR TITLE
show duration summary

### DIFF
--- a/v2/cmd/buildutil/instrumentation.go
+++ b/v2/cmd/buildutil/instrumentation.go
@@ -84,10 +84,13 @@ func (m *DurationMap) Stopwatch(name string) func() {
 	start := time.Now()
 
 	return func() {
+		d := time.Since(start).Truncate(time.Millisecond)
+
 		m.l.Lock()
 		defer m.l.Unlock()
+
 		m.m[name] = typeutil.JSONDuration{
-			Duration: time.Since(start).Truncate(time.Millisecond),
+			Duration: d,
 		}
 	}
 }

--- a/v2/cmd/buildutil/instrumentation.go
+++ b/v2/cmd/buildutil/instrumentation.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/rebuy-de/rebuy-go-sdk/v2/pkg/typeutil"
+	"github.com/sirupsen/logrus"
+)
+
+type Instrumentation struct {
+	l *sync.Mutex
+
+	Durations struct {
+		Steps     *DurationMap `json:"steps,omitempty"`
+		Testing   *DurationMap `json:"test,omitempty"`
+		Building  *DurationMap `json:"build,omitempty"`
+		Artifacts *DurationMap `json:"artifacts,omitempty"`
+		Upload    *DurationMap `json:"upload,omitempty"`
+	} `json:",omitempty"`
+
+	Sizes map[string]typeutil.JSONBytes `json:",omitempty"`
+}
+
+func NewInstrumentation() *Instrumentation {
+	inst := new(Instrumentation)
+	inst.l = new(sync.Mutex)
+
+	inst.Durations.Steps = NewDurationMap()
+	inst.Durations.Testing = NewDurationMap()
+	inst.Durations.Building = NewDurationMap()
+	inst.Durations.Artifacts = NewDurationMap()
+	inst.Durations.Upload = NewDurationMap()
+
+	return inst
+}
+
+func (i *Instrumentation) ReadSize(name string) {
+	fi, err := os.Stat(path.Join("dist", name))
+	if err != nil {
+		logrus.WithError(err).Errorf("Failed to get size of %s", name)
+		return
+	}
+
+	i.l.Lock()
+	defer i.l.Unlock()
+
+	if i.Sizes == nil {
+		i.Sizes = map[string]typeutil.JSONBytes{}
+	}
+
+	i.Sizes[name] = typeutil.JSONBytes{
+		Size: fi.Size(),
+	}
+}
+
+func Stopwatch(target *typeutil.JSONDuration) func() {
+	start := time.Now()
+	return func() {
+		target.Duration = time.Since(start).Truncate(time.Millisecond)
+	}
+}
+
+type DurationMap struct {
+	m map[string]typeutil.JSONDuration
+	l *sync.Mutex
+}
+
+func NewDurationMap() *DurationMap {
+	return &DurationMap{
+		m: map[string]typeutil.JSONDuration{},
+		l: new(sync.Mutex),
+	}
+}
+
+func (m *DurationMap) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.m)
+}
+
+func (m *DurationMap) Stopwatch(name string) func() {
+	start := time.Now()
+
+	return func() {
+		m.l.Lock()
+		defer m.l.Unlock()
+		m.m[name] = typeutil.JSONDuration{
+			Duration: time.Since(start).Truncate(time.Millisecond),
+		}
+	}
+}

--- a/v2/cmd/buildutil/logutil.go
+++ b/v2/cmd/buildutil/logutil.go
@@ -16,16 +16,3 @@ func dumpJSON(data interface{}) {
 	b = pretty.Color(b, pretty.TerminalStyle)
 	fmt.Fprintln(os.Stderr, string(b))
 }
-
-func byteFormat(b int64) string {
-	const unit = 1024
-	if b < unit {
-		return fmt.Sprintf("%d B", b)
-	}
-	div, exp := int64(unit), 0
-	for n := b / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
-}

--- a/v2/cmd/buildutil/main.go
+++ b/v2/cmd/buildutil/main.go
@@ -60,6 +60,10 @@ func NewRootCommand() *cobra.Command {
 			cmdutil.WithRun(runner.RunBuild),
 		)),
 		cmdutil.WithSubCommand(cmdutil.New(
+			"artifacts", "Create artifacts",
+			cmdutil.WithRun(runner.RunArtifacts),
+		)),
+		cmdutil.WithSubCommand(cmdutil.New(
 			"upload", "Upload artifacts to S3",
 			cmdutil.WithRun(runner.RunUpload),
 		)),

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -8,13 +8,14 @@ require (
 	github.com/google/uuid v1.0.0
 	github.com/goreleaser/nfpm v1.1.8
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/labstack/gommon v0.3.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.2 // indirect
 	github.com/tidwall/pretty v1.0.0
-	golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a // indirect
+	github.com/zpatrick/go-bytesize v0.0.0-20170214182126-40b68ac70b6a // indirect
 	golang.org/x/tools v0.0.0-20191018000036-341939e08647
 	gopkg.in/gemnasium/logrus-graylog-hook.v2 v2.0.7
 	gopkg.in/yaml.v2 v2.2.7

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -4,6 +4,7 @@ github.com/Masterminds/semver/v3 v3.0.2 h1:tRi7ENs+AaOUCH+j6qwNQgPYfV26dX3JNonq+
 github.com/Masterminds/semver/v3 v3.0.2/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/alecthomas/kingpin v2.2.6+incompatible/go.mod h1:59OFYbFVLKQKq+mqrL6Rw5bR0c3ACQaawgXx0QYndlE=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aws/aws-sdk-go v1.25.0 h1:MyXUdCesJLBvSSKYcaKeeEwxNUwUpG6/uqVYeH/Zzfo=
 github.com/aws/aws-sdk-go v1.25.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
@@ -64,6 +65,11 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=
+github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-zglob v0.0.1 h1:xsEx/XUoVlI6yXjqBK062zYhRTZltCNmYPx6v+8DNaY=
 github.com/mattn/go-zglob v0.0.1/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -95,12 +101,17 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
+github.com/zpatrick/go-bytesize v0.0.0-20170214182126-40b68ac70b6a h1:jUcnbVSYtTjCDmqiDMyi0Bfb4zBXxA942pJ8EMd90eY=
+github.com/zpatrick/go-bytesize v0.0.0-20170214182126-40b68ac70b6a/go.mod h1:DdN+lIGSIY7OU4mNq8TGLFoZvrJXcM/KRIn8sCPn1bs=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181025213731-e84da0312774 h1:a4tQYYYuK9QdeO/+kEvNYyuR21S+7ve5EANok6hABhI=
 golang.org/x/crypto v0.0.0-20181025213731-e84da0312774/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -129,6 +140,7 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e h1:o3PsSEY8E4eXWkXrIP9YJALUkVZqzHJT5DOasTyn8Vs=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313 h1:pczuHS43Cp2ktBEEmLwScxgjWsBSzdaQiKzUyf3DTTc=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/v2/pkg/typeutil/json.go
+++ b/v2/pkg/typeutil/json.go
@@ -1,0 +1,52 @@
+package typeutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"time"
+)
+
+type JSONDuration struct {
+	time.Duration
+}
+
+func (j JSONDuration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(j.Duration.String())
+}
+
+type JSONBytes struct {
+	Size int64
+}
+
+func (j JSONBytes) MarshalJSON() ([]byte, error) {
+	return json.Marshal(j.String())
+}
+
+func (j JSONBytes) String() string {
+	var (
+		pre = []string{"B", "KiB", "MiB", "GiB", "TiB"}
+
+		bits = math.Log2(float64(j.Size))
+		pos  = math.Floor(bits / 10)
+		exp  = math.Pow(1024, float64(pos))
+
+		short = float64(j.Size) / exp
+		sufix = pre[int(pos)]
+	)
+
+	if pos == 0 {
+		return fmt.Sprintf("%.0f%s", short, sufix)
+	}
+
+	if short < 10 {
+		return fmt.Sprintf("%.3f%s", short, sufix)
+	}
+
+	if short < 100 {
+		return fmt.Sprintf("%.2f%s", short, sufix)
+	}
+
+	return fmt.Sprintf("%.1f%s", short, sufix)
+
+}

--- a/v2/pkg/typeutil/json_test.go
+++ b/v2/pkg/typeutil/json_test.go
@@ -1,0 +1,45 @@
+package typeutil
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestByteFormat(t *testing.T) {
+	cases := []struct {
+		size int64
+		want string
+	}{
+		{size: 42, want: "42B"},
+		{size: 42 * 1024, want: "42.00KiB"},
+		{size: 42 * 1024 * 1024, want: "42.00MiB"},
+		{size: 42 * 1024 * 1024 * 1024, want: "42.00GiB"},
+		{size: 1337, want: "1.306KiB"},
+		{size: 1337 * 1024, want: "1.306MiB"},
+		{size: 1337 * 1024 * 1024, want: "1.306GiB"},
+		{size: 1337 * 1024 * 1024 * 1024, want: "1.306TiB"},
+		{size: 1, want: "1B"},
+		{size: 11, want: "11B"},
+		{size: 111, want: "111B"},
+		{size: 1111, want: "1.085KiB"},
+		{size: 11111, want: "10.85KiB"},
+		{size: 111111, want: "108.5KiB"},
+		{size: 1111111, want: "1.060MiB"},
+		{size: 11111111, want: "10.60MiB"},
+		{size: 111111111, want: "106.0MiB"},
+		{size: 1111111111, want: "1.035GiB"},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprint(tc.size), func(t *testing.T) {
+			b := JSONBytes{Size: tc.size}
+			have := b.String()
+
+			if tc.want != have {
+				t.Errorf("%s != %s", tc.want, have)
+			}
+
+		})
+	}
+
+}


### PR DESCRIPTION
Add a build summary at the end of the build.

It looks like this (see Travis):

```json
{
    "Durations": {
        "steps": {
            "all": "22.123s",
            "artifacts": "7.403s",
            "build": "4.83s",
            "info": "5.324s",
            "test": "3.74s",
            "upload": "5.449s",
            "vendor": "701ms"
        },
        "test": {
            "fmt": "50ms",
            "packages": "2.664s",
            "vet": "1.025s"
        },
        "build": {
            "buildutil-v2.0.0+snapshot.4.27d58c6-darwin-amd64": "1.864s",
            "buildutil-v2.0.0+snapshot.4.27d58c6-linux-amd64": "1.709s",
            "regenerator-v2.0.0+snapshot.4.27d58c6-darwin-amd64": "637ms",
            "regenerator-v2.0.0+snapshot.4.27d58c6-linux-amd64": "618ms"
        },
        "artifacts": {
            "buildutil-v2.0.0+snapshot.4.27d58c6-darwin-amd64": "0s",
            "buildutil-v2.0.0+snapshot.4.27d58c6-linux-amd64": "0s",
            "rebuy-go-sdk-v2.0.0+snapshot.4.27d58c6-darwin-amd64.tar.gz": "1.248s",
            "rebuy-go-sdk-v2.0.0+snapshot.4.27d58c6-linux-amd64.deb": "1.16s",
            "rebuy-go-sdk-v2.0.0+snapshot.4.27d58c6-linux-amd64.rpm": "3.818s",
            "rebuy-go-sdk-v2.0.0+snapshot.4.27d58c6-linux-amd64.tar.gz": "1.174s",
            "regenerator-v2.0.0+snapshot.4.27d58c6-darwin-amd64": "0s",
            "regenerator-v2.0.0+snapshot.4.27d58c6-linux-amd64": "0s"
        },
        "upload": {
            "s3://rebuy-github-releases/rebuy-go-sdk/buildutil-v2.0.0+snapshot.4.27d58c6-darwin-amd64": "2.015s",
            "s3://rebuy-github-releases/rebuy-go-sdk/buildutil-v2.0.0+snapshot.4.27d58c6-linux-amd64": "2.32s",
            "s3://rebuy-github-releases/rebuy-go-sdk/regenerator-v2.0.0+snapshot.4.27d58c6-darwin-amd64": "499ms",
            "s3://rebuy-github-releases/rebuy-go-sdk/regenerator-v2.0.0+snapshot.4.27d58c6-linux-amd64": "613ms"
        }
    },
    "Sizes": {
        "buildutil-v2.0.0+snapshot.4.27d58c6-darwin-amd64": "15.82MiB",
        "buildutil-v2.0.0+snapshot.4.27d58c6-linux-amd64": "14.54MiB",
        "rebuy-go-sdk-v2.0.0+snapshot.4.27d58c6-darwin-amd64.tar.gz": "6.688MiB",
        "rebuy-go-sdk-v2.0.0+snapshot.4.27d58c6-linux-amd64.deb": "6.390MiB",
        "rebuy-go-sdk-v2.0.0+snapshot.4.27d58c6-linux-amd64.rpm": "6.371MiB",
        "rebuy-go-sdk-v2.0.0+snapshot.4.27d58c6-linux-amd64.tar.gz": "6.385MiB",
        "regenerator-v2.0.0+snapshot.4.27d58c6-darwin-amd64": "3.833MiB",
        "regenerator-v2.0.0+snapshot.4.27d58c6-linux-amd64": "3.492MiB"
    }
}
```