### PR TITLE
Correctly split dirty files

### DIFF
--- a/v2/cmd/buildutil/info.go
+++ b/v2/cmd/buildutil/info.go
@@ -231,7 +231,7 @@ func CollectBuildInformation(ctx context.Context, p BuildParameters) (BuildInfo,
 
 	status := strings.TrimSpace(e.OutputString("git", "status", "-s"))
 	if status != "" {
-		info.Commit.DirtyFiles = strings.Split(status, "\n")
+		info.Commit.DirtyFiles = strings.Split(status, "\n ")
 	}
 
 	nameMatch := regexp.MustCompile(`([^/]+)(/v\d+)?$`).FindStringSubmatch(info.Go.Module)


### PR DESCRIPTION
Current output is 
```
        "DirtyFiles": [
            "M cmd/util.go",
            " M go.mod",
            " M go.sum"
        ]
```
since `git status -s` adds a whitespace before each line.