### PR TITLE
Revert "make wrapper symlinkable"

### DIFF
--- a/v2/buildutil
+++ b/v2/buildutil
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-cd "$(dirname "$(readlink -f "$0")")"
+cd $(dirname "$0")
 
 VERSION="v2.0.0+alpha.4"
 


### PR DESCRIPTION
Reverts rebuy-de/rebuy-go-sdk#32

Unfortunately this doesn't work on Mac platforms, so we'll remove it.