### PR TITLE
Only print colored output on terminals

### DIFF
--- a/v2/cmd/buildutil/logutil.go
+++ b/v2/cmd/buildutil/logutil.go
@@ -7,12 +7,16 @@ import (
 
 	"github.com/rebuy-de/rebuy-go-sdk/v2/pkg/cmdutil"
 	"github.com/tidwall/pretty"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 func dumpJSON(data interface{}) {
 	b, err := json.MarshalIndent(data, "", "    ")
 	cmdutil.Must(err)
 
-	b = pretty.Color(b, pretty.TerminalStyle)
+	if terminal.IsTerminal(int(os.Stdout.Fd())) {
+		b = pretty.Color(b, pretty.TerminalStyle)
+	}
+
 	fmt.Fprintln(os.Stderr, string(b))
 }

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/tidwall/pretty v1.0.0
+	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/tools v0.0.0-20200203023011-6f24f261dadb
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/client-go v0.17.2


### PR DESCRIPTION
Makes Jenkins happy so this will disappear:
```
    [94m"Go"[0m: {
        [94m"Name"[0m: [92m"regrant"[0m,
        [94m"Module"[0m: [92m"github.com/rebuy-de/regrant"[0m,
        [94m"Dir"[0m: [92m"/var/lib/jenkins/workspace/rebuy-de_regrant_master"[0m
    },
```