### PR TITLE
make info more fault tolerant

### DIFF
--- a/v2/cmd/buildutil/info.go
+++ b/v2/cmd/buildutil/info.go
@@ -216,8 +216,8 @@ func CollectBuildInformation(ctx context.Context, p BuildParameters) (BuildInfo,
 	e := executil.NewChainExecutor(ctx)
 
 	info.BuildDate = time.Now().Format(time.RFC3339)
-	info.Go.Module = e.OutputString("go", "list", "-m")
-	info.Go.Dir = e.OutputString("go", "list", "-m", "-f", "{{.Dir}}")
+	info.Go.Module = e.OutputString("go", "list", "-m", "-mod=readonly")
+	info.Go.Dir = e.OutputString("go", "list", "-m", "-mod=readonly", "-f", "{{.Dir}}")
 	info.System.OS = e.OutputString("go", "env", "GOOS")
 	info.System.Arch = e.OutputString("go", "env", "GOARCH")
 	info.System.Ext = e.OutputString("go", "env", "GOEXE")


### PR DESCRIPTION
*kutil* fails with this error:

```
running command `go list -m`" Args="[go list -m]" Dir=
go: inconsistent vendoring in /var/lib/jenkins/workspace/rebuy-de_rebuy-kutil_master:
	github.com/acarl005/stripansi@v0.0.0-20180116102854-5a71ef0e047d: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod

run 'go mod vendor' to sync, or use -mod=mod or -mod=readonly to ignore the vendor directory
```

It looks like Go 1.14 changed some behavior. Nevertheless, the buildutil uses `go list -m` in the info step in the very beginning and before `go mod vendor` get called. Therefore we go with the suggested `-mod=readonly` option.