### PR TITLE
make info more fault tolerant

### DIFF
--- a/v2/cmd/buildutil/info.go
+++ b/v2/cmd/buildutil/info.go
@@ -216,8 +216,8 @@ func CollectBuildInformation(ctx context.Context, p BuildParameters) (BuildInfo,
 	e := executil.NewChainExecutor(ctx)
 
 	info.BuildDate = time.Now().Format(time.RFC3339)
-	info.Go.Module = e.OutputString("go", "list", "-m", "-mod=readonly")
-	info.Go.Dir = e.OutputString("go", "list", "-m", "-mod=readonly", "-f", "{{.Dir}}")
+	info.Go.Module = e.OutputString("go", "list", "-m", "-mod=mod")
+	info.Go.Dir = e.OutputString("go", "list", "-m", "-mod=mod", "-f", "{{.Dir}}")
 	info.System.OS = e.OutputString("go", "env", "GOOS")
 	info.System.Arch = e.OutputString("go", "env", "GOARCH")
 	info.System.Ext = e.OutputString("go", "env", "GOEXE")


### PR DESCRIPTION
> Follow up to https://github.com/rebuy-de/rebuy-go-sdk/pull/40

`-mod=readonly` does not seem to work, too.

I tested it on Jenkins directly:

```
bash-5.0# go list -m
go: inconsistent vendoring in /repo:
	github.com/rebuy-de/rebuy-go-sdk/v2@v2.2.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/rebuy-de/rebuy-go-sdk/v2@v2.0.1-0.20191011155542-6ed28a922985: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod

run 'go mod vendor' to sync, or use -mod=mod or -mod=readonly to ignore the vendor directory
bash-5.0# go list -m -mod=readonly
go: updates to go.mod needed, disabled by -mod=readonly
bash-5.0# go list -m -mod=mod
github.com/rebuy-de/rebuy-kutil
```