### PR TITLE
be more tolerant when checking versions

### DIFF
--- a/cmd/buildutil/info.go
+++ b/cmd/buildutil/info.go
@@ -32,7 +32,7 @@ func ParseVersion(s string) (Version, error) {
 		err error
 
 		reCore       = regexp.MustCompile(`^v?([0-9]+)\.([0-9]+)\.([0-9]+)([\-\+].+)?$`)
-		rePreRelease = regexp.MustCompile(`^\+(alpha|beta|rc)\.[0-9]+$`)
+		rePreRelease = regexp.MustCompile(`^[\-\+](alpha|beta|rc)\.?[0-9]+$`)
 		reDescribe   = regexp.MustCompile(`\-([0-9]+)-g?([0-9a-f]+)(-dirty)?$`)
 	)
 

--- a/cmd/buildutil/info_test.go
+++ b/cmd/buildutil/info_test.go
@@ -42,6 +42,11 @@ func TestParseVersion(t *testing.T) {
 			in:   "v1.6.0+alpha.1-20-gb9e9373-dirty",
 			out:  "v1.6.0+dirty.20.b9e9373",
 		},
+		{
+			name: "release-candidate",
+			in:   "v3.0.0-rc2",
+			out:  "v3.0.0+rc2",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
I named the RC release `v3.0.0-rc1`, but the convention says `v3.0.0+rc.1`. Being more tolerant here.