### PR TITLE
handle nothing-to-do in redis vacuuming

### DIFF
--- a/pkg/redisutil/index.go
+++ b/pkg/redisutil/index.go
@@ -34,6 +34,10 @@ func IndexVacuum(ctx context.Context, c RedisIndexer, indexKey string, dataKeyPr
 		}
 	}
 
+	if len(expired) == 0 {
+		return nil
+	}
+
 	err = c.SRem(ctx, indexKey, expired...).Err()
 	return errors.Wrap(err, "failed to delete expired keys")
 }


### PR DESCRIPTION
Fixing:

```
DEBU[0003] ERR wrong number of arguments for 'srem' command
```

when there is nothing to remove.