### PR TITLE
add Podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 FROM golang:1.16-alpine as builder
 
 RUN apk add --no-cache git curl openssl bash
+RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/community podman
 
 # Install Go Tools
 # RUN --mount=type=cache,id=go-build-cache,target=/root/.cache/go-build \


### PR DESCRIPTION
Unfortunately it does not work yet.

With the official image it works:

```
podman \                                                                           
  run \                        
    --privileged \
    --rm \
    --ulimit host \
    -v /dev/fuse:/dev/fuse:rw \
    -v ./mycontainers:/var/lib/containers:rw \
    quay.io/podman/stable \
      podman \
        run \
          --rm \
          --user 0 \
          docker.io/library/alpine ls
```

with the SDK image it does not:

```
podman \
  run \
    --privileged \
    --rm \
    --ulimit host \
    -v /dev/fuse:/dev/fuse:rw \
    -v ./mycontainers:/var/lib/containers:rw \
    rebuy-go-sdk:podman \
      podman \
        run \
          --rm \
          --user 0 \
          docker.io/library/alpine ls
time="2021-03-05T13:31:51Z" level=error msg="'overlay' is not supported over extfs at \"/var/lib/containers/storage/overlay\""
Error: kernel does not support overlay fs: 'overlay' is not supported over extfs at "/var/lib/containers/storage/overlay": backing file system is unsupported for this graph driver
```