### PR TITLE
CLOUD-2822 add toolstack label

### DIFF
--- a/cmd/buildutil/info.go
+++ b/cmd/buildutil/info.go
@@ -143,9 +143,10 @@ func (i SystemInfo) Name() string {
 }
 
 type BuildInfo struct {
-	BuildDate string
-	System    SystemInfo
-	Version   Version
+	BuildDate  string
+	System     SystemInfo
+	Version    Version
+	SDKVersion Version
 
 	Go struct {
 		Name    string
@@ -230,6 +231,11 @@ func CollectBuildInformation(ctx context.Context, p BuildParameters) (BuildInfo,
 	info.Commit.Date = time.Unix(e.OutputInt64("git", "show", "-s", "--format=%ct"), 0).Format(time.RFC3339)
 	info.Commit.Hash = e.OutputString("git", "rev-parse", "HEAD")
 	info.Commit.Branch = e.OutputString("git", "rev-parse", "--abbrev-ref", "HEAD")
+
+	info.SDKVersion, err = ParseVersion(e.OutputString("go", "list", "-mod=readonly", "-m", "-f", "{{.Version}}", "github.com/rebuy-de/rebuy-go-sdk/..."))
+	if err != nil {
+		logrus.WithError(err).Error("Failed to parse sdk-version")
+	}
 
 	info.Version, err = ParseVersion(e.OutputString("git", "describe", "--always", "--dirty", "--tags"))
 	if err != nil {

--- a/cmd/buildutil/runner.go
+++ b/cmd/buildutil/runner.go
@@ -183,6 +183,7 @@ func (r *Runner) RunBuild(ctx context.Context, cmd *cobra.Command, args []string
 			{name: "GoModule", value: r.Info.Go.Module},
 			{name: "GoPackage", value: target.Package},
 			{name: "GoVersion", value: r.Info.Go.Version},
+			{name: "SDKVersion", value: r.Info.SDKVersion.String()},
 			{name: "BuildDate", value: r.Info.BuildDate},
 			{name: "CommitDate", value: r.Info.Commit.Date},
 			{name: "CommitHash", value: r.Info.Commit.Hash},

--- a/pkg/cmdutil/version.go
+++ b/pkg/cmdutil/version.go
@@ -15,6 +15,7 @@ var (
 	GoModule   = "unknown"
 	GoPackage  = "unknown"
 	GoVersion  = "unknown"
+	SDKVersion = "unknown"
 	BuildDate  = "unknown"
 	CommitDate = "unknown"
 	CommitHash = "unknown"
@@ -34,6 +35,7 @@ func NewVersionCommand() *cobra.Command {
 			fmt.Printf("GoModule:   %s\n", GoModule)
 			fmt.Printf("GoPackage:  %s\n", GoPackage)
 			fmt.Printf("GoVersion:  %s\n", GoVersion)
+			fmt.Printf("SDKVersion: %s\n", SDKVersion)
 			fmt.Printf("BuildDate:  %s\n", BuildDate)
 			fmt.Printf("CommitDate: %s\n", CommitDate)
 			fmt.Printf("CommitHash: %s\n", CommitHash)

--- a/pkg/instutil/toolstack.go
+++ b/pkg/instutil/toolstack.go
@@ -1,0 +1,33 @@
+package instutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rebuy-de/rebuy-go-sdk/v3/pkg/cmdutil"
+)
+
+func init() {
+	gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "rebuy",
+		Name:      "toolstack",
+	}, []string{
+		"toolstack",
+		"language",
+		"language_version",
+		"sdk",
+		"sdk_version",
+	})
+	prometheus.MustRegister(gauge)
+
+	major := strings.SplitN(cmdutil.SDKVersion, ".", 2)[0]
+
+	gauge.WithLabelValues(
+		fmt.Sprintf("golang.rebuy-go-sdk.%s", major),
+		"golang",
+		cmdutil.GoVersion,
+		"rebuy-go-sdk",
+		cmdutil.SDKVersion,
+	).Set(1)
+}


### PR DESCRIPTION
> https://jira.rebuy.de/browse/CLOUD-2822

```
~github.com/rebuy-de/cloud-audit-opa on  master [!] 
❯ curl localhost:8090/metrics -sS | ack -i toolstack
# HELP rebuy_toolstack 
# TYPE rebuy_toolstack gauge
rebuy_toolstack{language="golang",language_version="1.16.6",sdk="rebuy-go-sdk",sdk_version="v3.7.0",toolstack="golang.rebuy-go-sdk.v3"} 1
```

I am not sure whether it make sense to automagically register the toolstack metrics by using the `init` function.