### PR TITLE
remove chain executor

### DIFF
--- a/cmd/buildutil/chain.go
+++ b/cmd/buildutil/chain.go
@@ -1,4 +1,4 @@
-package executil
+package main
 
 import (
 	"bytes"
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/rebuy-de/rebuy-go-sdk/v4/pkg/executil"
 )
 
 type ChainExecutor struct {
@@ -36,7 +38,7 @@ func (e *ChainExecutor) Run(command string, args ...string) {
 	c := exec.Command(command, args...)
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
-	e.err = Run(e.ctx, c)
+	e.err = executil.Run(e.ctx, c)
 }
 
 func (e *ChainExecutor) OutputString(command string, args ...string) string {
@@ -52,7 +54,7 @@ func (e *ChainExecutor) OutputString(command string, args ...string) string {
 	out := bytes.Buffer{}
 	c.Stdout = &out
 	c.Stderr = os.Stderr
-	e.err = Run(e.ctx, c)
+	e.err = executil.Run(e.ctx, c)
 	return strings.TrimSpace(out.String())
 }
 

--- a/cmd/buildutil/info.go
+++ b/cmd/buildutil/info.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rebuy-de/rebuy-go-sdk/v4/pkg/cmdutil"
-	"github.com/rebuy-de/rebuy-go-sdk/v4/pkg/executil"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/tools/go/packages"
 )
@@ -220,7 +219,7 @@ func CollectBuildInformation(ctx context.Context, p BuildParameters) (BuildInfo,
 
 	logrus.Info("Collecting build information")
 
-	e := executil.NewChainExecutor(ctx)
+	e := NewChainExecutor(ctx)
 
 	info.BuildDate = time.Now().Format(time.RFC3339)
 	info.Go.Module = e.OutputString(p.GoCommand, "list", "-m", "-mod=mod")


### PR DESCRIPTION
> Part of release v4 https://github.com/rebuy-de/rebuy-go-sdk/pull/91

The chainexecutor is only used in one place. Therefore we can remove it.
