### PR TITLE
improve getters and setters for redis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/rebuy-de/rebuy-go-sdk/v4
 go 1.18
 
 require (
-	github.com/alicebob/miniredis/v2 v2.16.0
+	github.com/alicebob/miniredis/v2 v2.18.0
 	github.com/aws/aws-sdk-go-v2 v1.10.0
 	github.com/aws/aws-sdk-go-v2/config v1.9.0
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.6.0
@@ -121,7 +121,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/xanzy/ssh-agent v0.3.1 // indirect
-	github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da // indirect
+	github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/mod v0.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a h1:HbKu58rmZpUGpz5+4FfNmIU+FmZg2P3Xaj2v2bfNWmk=
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
-github.com/alicebob/miniredis/v2 v2.16.0 h1:ALkyFg7bSTEd1Mkrb4ppq4fnwjklA59dVtIehXCUZkU=
-github.com/alicebob/miniredis/v2 v2.16.0/go.mod h1:gquAfGbzn92jvtrSC69+6zZnwSODVXVpYDRaGhWaL6I=
+github.com/alicebob/miniredis/v2 v2.18.0 h1:EPUGD69ou4Uw4c81t9NLh0+dSou46k4tFEvf498FJ0g=
+github.com/alicebob/miniredis/v2 v2.18.0/go.mod h1:gquAfGbzn92jvtrSC69+6zZnwSODVXVpYDRaGhWaL6I=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -653,8 +653,9 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da h1:NimzV1aGyq29m5ukMK0AMWEhFaL/lrEOaephfuoiARg=
 github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da/go.mod h1:E1AXubJBdNmFERAOucpDIxNzeGfLzg0mYh+UfMWdChA=
+github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9 h1:k/gmLsJDWwWqbLCur2yWnJzwQEKRcAHXo6seXGuSwWw=
+github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9/go.mod h1:E1AXubJBdNmFERAOucpDIxNzeGfLzg0mYh+UfMWdChA=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=

--- a/pkg/redisutil/json.go
+++ b/pkg/redisutil/json.go
@@ -1,35 +1,127 @@
 package redisutil
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"time"
 
 	"github.com/go-redis/redis/v8"
+	"github.com/pkg/errors"
 )
 
 type RedisGetter interface {
 	Get(context.Context, string) *redis.StringCmd
 }
 
-func JSONGet(ctx context.Context, c RedisGetter, key string, v interface{}) error {
+func JSONGet[T any](ctx context.Context, c RedisGetter, key string) (*T, error) {
 	payload, err := c.Get(ctx, key).Result()
+	if err == redis.Nil {
+		return nil, nil
+	}
 	if err != nil {
-		return err
+		return nil, errors.WithStack(err)
 	}
 
-	return json.Unmarshal([]byte(payload), v)
+	return unmarshalGzipJSON[T](payload)
+}
+
+func unmarshalJSON[T any](payload string) (*T, error) {
+	var v T
+	err := json.Unmarshal([]byte(payload), &v)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return &v, nil
+}
+
+func unmarshalGzipJSON[T any](payload string) (*T, error) {
+	raw := []byte(payload)
+
+	if len(raw) < 2 || raw[0] != 0x1f || raw[1] != 0x8b {
+		// Decode directly, if it does not start with the gzip magic bytes.
+		return unmarshalJSON[T](payload)
+	}
+
+	buf := bytes.NewBuffer(raw)
+	zr, err := gzip.NewReader(buf)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer zr.Close()
+
+	var v T
+	err = json.NewDecoder(zr).Decode(&v)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return &v, nil
 }
 
 type RedisSetter interface {
 	Set(context.Context, string, interface{}, time.Duration) *redis.StatusCmd
+	GetSet(context.Context, string, interface{}) *redis.StringCmd
 }
 
-func JSONSet(ctx context.Context, c RedisSetter, key string, v interface{}, expiration time.Duration) error {
-	payload, err := json.Marshal(v)
+func GzipJSONSet[T any](ctx context.Context, c RedisSetter, key string, v T, expiration time.Duration) error {
+	payload, err := marshalGzipJSON(v)
 	if err != nil {
 		return err
 	}
 
-	return c.Set(ctx, key, string(payload), expiration).Err()
+	err = c.Set(ctx, key, string(payload), expiration).Err()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func GzipJSONGetSet[T any](ctx context.Context, c RedisSetter, key string, v T) (bool, error) {
+	payload, err := marshalGzipJSON(v)
+	if err != nil {
+		return false, err
+	}
+
+	old, err := c.GetSet(ctx, key, string(payload)).Result()
+	if err == redis.Nil {
+		// Return true even if the actual value is empty or nil, because
+		// deleting a key would be its own funktion.
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return old != string(payload), nil
+}
+
+func marshalGzipJSON[T any](v T) (string, error) {
+	jsonBuf, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+
+	if len(jsonBuf) < 100 {
+		return string(jsonBuf), nil
+	}
+
+	resultBuf := new(bytes.Buffer)
+	resultWriter, err := gzip.NewWriterLevel(resultBuf, gzip.BestCompression)
+	if err != nil {
+		return "", err
+	}
+	_, err = resultWriter.Write(jsonBuf)
+	if err != nil {
+		return "", err
+	}
+
+	err = resultWriter.Close()
+	if err != nil {
+		return "", err
+	}
+
+	return resultBuf.String(), nil
 }

--- a/pkg/redisutil/json_test.go
+++ b/pkg/redisutil/json_test.go
@@ -1,0 +1,85 @@
+package redisutil
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testJSONData struct {
+	ID    int
+	Stuff string
+}
+
+func TestGzipJSONSetGet(t *testing.T) {
+	fake := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{
+		Addr: fake.Addr(),
+	})
+
+	ctx := context.Background()
+	long := testJSONData{
+		ID:    42,
+		Stuff: strings.Repeat("ha", 100),
+	}
+
+	t.Run("Set", func(t *testing.T) {
+		err := GzipJSONSet(ctx, client, "test", long, time.Hour)
+		require.NoError(t, err)
+
+		payload, err := fake.Get("test")
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x1f, 0x8b}, []byte(payload)[0:2])
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		retrieved, err := JSONGet[testJSONData](ctx, client, "test")
+		require.NoError(t, err)
+		require.Equal(t, &long, retrieved)
+	})
+}
+
+func TestGzipJSONSetGetChanged(t *testing.T) {
+	fake := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{
+		Addr: fake.Addr(),
+	})
+
+	ctx := context.Background()
+	long := testJSONData{
+		ID:    42,
+		Stuff: strings.Repeat("ha", 100),
+	}
+
+	t.Run("SetInitial", func(t *testing.T) {
+		changed, err := GzipJSONGetSet(ctx, client, "test", long)
+		require.NoError(t, err)
+		assert.True(t, changed)
+
+		payload, err := fake.Get("test")
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x1f, 0x8b}, []byte(payload)[0:2])
+	})
+
+	t.Run("SetSame", func(t *testing.T) {
+		changed, err := GzipJSONGetSet(ctx, client, "test", long)
+		require.NoError(t, err)
+		assert.False(t, changed)
+
+		payload, err := fake.Get("test")
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x1f, 0x8b}, []byte(payload)[0:2])
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		retrieved, err := JSONGet[testJSONData](ctx, client, "test")
+		require.NoError(t, err)
+		require.Equal(t, &long, retrieved)
+	})
+}


### PR DESCRIPTION
> https://github.com/rebuy-de/rebuy-go-sdk/pull/91

This improves  getters and setters for redis utilizing generics. This provides functions to get and set json-encoded values to Redis with a single line. Additionally it is able to read gzipped JSON data and it automatically gzips the data, if it has more than 100 bytes. There is also a set function that returns whether the value in redis changed.

*Breaking Change:* The existing `JSONGet` and `JSONSet` are replaces by ones using generics.