### PR TITLE
Remove 'go mod tidy' from buildutil

### DIFF
--- a/buildutil
+++ b/buildutil
@@ -1,6 +1,5 @@
 #!/usr/bin/env sh
 set -eu
-go mod tidy
 go mod vendor
 go generate ./...
 exec go run github.com/rebuy-de/rebuy-go-sdk/v4/cmd/buildutil "$@"

--- a/examples/full/buildutil
+++ b/examples/full/buildutil
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-go mod tidy
+set -eu
 go mod vendor
 go generate ./...
 exec go run github.com/rebuy-de/rebuy-go-sdk/v4/cmd/buildutil "$@"

--- a/examples/minimal/buildutil
+++ b/examples/minimal/buildutil
@@ -1,6 +1,5 @@
 #!/usr/bin/env sh
 set -eu
-go mod tidy
 go mod vendor
 go generate ./...
 exec go run github.com/rebuy-de/rebuy-go-sdk/v4/cmd/buildutil "$@"


### PR DESCRIPTION
Removing `go mod tidy` so CI jobs don't change file contents.