### PR TITLE
fix dirtyfiles listing

### DIFF
--- a/cmd/buildutil/info.go
+++ b/cmd/buildutil/info.go
@@ -250,7 +250,9 @@ func CollectBuildInformation(ctx context.Context, p BuildParameters) (BuildInfo,
 
 	status := strings.TrimSpace(e.OutputString("git", "status", "-s"))
 	if status != "" {
-		info.Commit.DirtyFiles = strings.Split(status, "\n ")
+		for _, file := range strings.Split(status, "\n") {
+			info.Commit.DirtyFiles = append(info.Commit.DirtyFiles, strings.TrimSpace(file))
+		}
 	}
 
 	nameMatch := regexp.MustCompile(`([^/]+)(/v\d+)?$`).FindStringSubmatch(info.Go.Module)


### PR DESCRIPTION
Should fix this:

```
        "DirtyFiles": [
            "M Dockerfile",
            "M buildutil",
            "M go.mod",
            "M go.sum\n?? tools.go"
        ]
```