### PR TITLE
improve shutdown behaviour

### DIFF
--- a/examples/full/cmd/server.go
+++ b/examples/full/cmd/server.go
@@ -33,10 +33,9 @@ func (s *Server) Run(ctx context.Context) error {
 	// running routines and should used once on program startup.
 	group, ctx := errgroup.WithContext(ctx)
 
-	// Set up the admin API and defer the function that it returns. The admin
-	// API lifecycle differs from the context, so it actually is the last thing
-	// that gets shut down.
-	defer webutil.AdminAPIListenAndServe(ctx)()
+	// Set up the admin API. The admin API lifecycle differs from the context,
+	// so it actually is the last thing that gets shut down.
+	webutil.AdminAPIListenAndServe(ctx)
 
 	// Other background processes.
 	s.setupHTTPServer(ctx, group)

--- a/examples/full/cmd/server.go
+++ b/examples/full/cmd/server.go
@@ -27,12 +27,6 @@ type Server struct {
 }
 
 func (s *Server) Run(ctx context.Context) error {
-	// Creating a new context, so we can have two stages for the graceful
-	// shutdown. First is to make pod unready (within the admin api) and the
-	// seconds is all the rest.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	ctx = InstInit(ctx)
 
 	// Using a errors group is a good practice to manage multiple parallel

--- a/pkg/cmdutil/context.go
+++ b/pkg/cmdutil/context.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -46,4 +47,55 @@ func wrapRootConext(run RunFuncWithContext) RunFunc {
 		run(SignalRootContext(), cmd, args)
 	}
 
+}
+
+// ContextWithDelay delays the context cancel by the given delay. In the
+// background it creates a new context with ContextWithValuesFrom and cancels
+// it after the original one got canceled.
+func ContextWithDelay(in context.Context, delay time.Duration) context.Context {
+	out := ContextWithValuesFrom(in)
+	out, cancel := context.WithCancel(out)
+
+	go func() {
+		defer cancel()
+		<-in.Done()
+		time.Sleep(delay)
+	}()
+	return out
+}
+
+type compositeContext struct {
+	deadline context.Context
+	done     context.Context
+	err      context.Context
+	value    context.Context
+}
+
+func (c compositeContext) Deadline() (deadline time.Time, ok bool) {
+	return c.deadline.Deadline()
+}
+func (c compositeContext) Done() <-chan struct{} {
+	return c.done.Done()
+}
+
+func (c compositeContext) Err() error {
+	return c.err.Err()
+}
+
+func (c compositeContext) Value(key any) any {
+	return c.value.Value(key)
+}
+
+// ContextWithValuesFrom creates a new context, but still references the values
+// from the given context. This is helpful if a background context is needed
+// that needs to have the values of an exiting context.
+func ContextWithValuesFrom(value context.Context) context.Context {
+	bg := context.Background()
+
+	return &compositeContext{
+		deadline: bg,
+		done:     bg,
+		err:      bg,
+		value:    value,
+	}
 }

--- a/pkg/webutil/admin.go
+++ b/pkg/webutil/admin.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rebuy-de/rebuy-go-sdk/v4/pkg/logutil"
 )
 
-func AdminAPIListenAndServe(ctx context.Context, healthy ...func() error) func() {
+func AdminAPIListenAndServe(ctx context.Context, healthy ...func() error) {
 	ctx = logutil.Start(ctx, "admin-api")
 	mux := http.NewServeMux()
 
@@ -46,8 +46,9 @@ func AdminAPIListenAndServe(ctx context.Context, healthy ...func() error) func()
 	// The admin api gets a its own context, because we want to delay the
 	// server shutdown as long as possible. The reason for this is that Istio
 	// starts to block all outgoing connections as soon as there is no
-	// listening server anymore.
-	bg, cancel := context.WithCancel(context.Background())
+	// listening server anymore. Also a graceful shutdown is not needed for the
+	// admin API, so it is also not necessary to cancel the context.
+	bg := context.Background()
 
 	go func() {
 		logutil.Get(ctx).Debugf("admin api listening on port 8090")
@@ -57,6 +58,4 @@ func AdminAPIListenAndServe(ctx context.Context, healthy ...func() error) func()
 			logutil.Get(ctx).Error(err.Error())
 		}
 	}()
-
-	return cancel
 }

--- a/pkg/webutil/server.go
+++ b/pkg/webutil/server.go
@@ -11,11 +11,11 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// ListenAndServerWithContext does the same as http.ListenAndServe with the
+// ListenAndServeWithContext does the same as http.ListenAndServe with the
 // difference that is properly utilises the context. This means it does a
 // graceful shutdown when the context is done and a context cancellation gets
 // propagated down to the actual request context.
-func ListenAndServerWithContext(ctx context.Context, addr string, handler http.Handler) error {
+func ListenAndServeWithContext(ctx context.Context, addr string, handler http.Handler) error {
 	server := &http.Server{
 		Addr:    addr,
 		Handler: handler,


### PR DESCRIPTION
* add option to define custom health checks
* keep the admin api up as long as possible, so the Istio preStop hook works as expected
* fix a typo: `ListenAndServerWithContext` → `ListenAndServeWithContext`