### PR TITLE
Add support for using PGO flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.19'
+        go-version: '1.20'
     - name: Checkout code
       uses: actions/checkout@v3
       with:

--- a/cmd/buildutil/info.go
+++ b/cmd/buildutil/info.go
@@ -207,6 +207,7 @@ type TargetInfo struct {
 	Outfile string
 	System  SystemInfo
 	CGO     bool
+	PGO     string
 }
 
 func CollectBuildInformation(ctx context.Context, p BuildParameters) (BuildInfo, error) {
@@ -311,6 +312,7 @@ func CollectBuildInformation(ctx context.Context, p BuildParameters) (BuildInfo,
 					Name:    path.Base(pkg.PkgPath),
 					System:  targetSystem,
 					CGO:     p.CGO,
+					PGO:     p.PGO,
 				}
 
 				if pkg.PkgPath == info.Go.Module {

--- a/cmd/buildutil/runner.go
+++ b/cmd/buildutil/runner.go
@@ -48,6 +48,7 @@ type BuildParameters struct {
 	GoCommand string
 
 	CGO bool
+	PGO string
 }
 
 type Runner struct {
@@ -81,6 +82,9 @@ func (r *Runner) Bind(cmd *cobra.Command) error {
 	cmd.PersistentFlags().BoolVar(
 		&r.Parameters.CGO, "cgo", false,
 		"Enable CGO.")
+	cmd.PersistentFlags().StringVar(
+		&r.Parameters.PGO, "pgo", "off",
+		"Sets input for PGO option.")
 	cmd.PersistentFlags().StringVar(
 		&r.Parameters.GoCommand, "go-command", "go",
 		"Which Go command to use.")
@@ -214,6 +218,7 @@ func (r *Runner) RunBuild(ctx context.Context, cmd *cobra.Command, args []string
 		call(ctx, r.Parameters.GoCommand, "build",
 			"-o", r.dist(target.Outfile),
 			"-ldflags", "-s -w "+strings.Join(ldFlags, " "),
+			"-pgo", target.PGO,
 			target.Package)
 
 		r.Inst.ReadSize(target.Outfile)

--- a/examples/full/Dockerfile
+++ b/examples/full/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine as builder
+FROM golang:1.20-alpine as builder
 
 RUN apk add --no-cache git openssl
 

--- a/examples/full/go.mod
+++ b/examples/full/go.mod
@@ -1,6 +1,6 @@
 module github.com/rebuy-de/rebuy-go-sdk/v4/examples/full
 
-go 1.19
+go 1.20
 
 replace github.com/rebuy-de/rebuy-go-sdk/v4 => ../..
 

--- a/examples/minimal/Dockerfile
+++ b/examples/minimal/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine as builder
+FROM golang:1.20-alpine as builder
 
 RUN apk add --no-cache git openssl
 

--- a/examples/minimal/go.mod
+++ b/examples/minimal/go.mod
@@ -1,6 +1,6 @@
 module github.com/rebuy-de/rebuy-go-sdk/v4/examples/minimal
 
-go 1.19
+go 1.20
 
 replace github.com/rebuy-de/rebuy-go-sdk/v4 => ../..
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rebuy-de/rebuy-go-sdk/v4
 
-go 1.19
+go 1.20
 
 require (
 	github.com/afiskon/promtail-client v0.0.0-20190305142237-506f3f921e9c


### PR DESCRIPTION
This obviously only works with Go >1.20, not sure if we should do a major release or check in code and only apply the flag when the Go version matches. Any opinions?