### PR TITLE
improve auth handlers

### DIFF
--- a/examples/full/go.mod
+++ b/examples/full/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	gitlab.com/digitalxero/go-conventional-commit v1.0.7 // indirect
 	golang.org/x/crypto v0.8.0 // indirect
+	golang.org/x/exp v0.0.0-20230420155640-133eef4313cb // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect

--- a/examples/full/go.sum
+++ b/examples/full/go.sum
@@ -250,6 +250,8 @@ golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 golang.org/x/crypto v0.8.0 h1:pd9TJtTueMTVQXzk8E2XESSMQDj/U7OUu0PqJqPXQjQ=
 golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=
+golang.org/x/exp v0.0.0-20230420155640-133eef4313cb h1:rhjz/8Mbfa8xROFiH+MQphmAmgqRM0bOMnytznhWEXk=
+golang.org/x/exp v0.0.0-20230420155640-133eef4313cb/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.6.0/go.mod h1:4mET923SAdbXp2ki8ey+zGs1SLqsuM2Y0uvdZR/fUNI=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=

--- a/pkg/typeutil/context.go
+++ b/pkg/typeutil/context.go
@@ -1,0 +1,33 @@
+package typeutil
+
+import (
+	"context"
+	"fmt"
+)
+
+func FromContext[T any](ctx context.Context, key string) *T {
+	raw := ctx.Value(key)
+	if raw == nil {
+		return nil
+	}
+
+	typed, ok := raw.(*T)
+	if !ok {
+		return nil
+	}
+
+	return typed
+}
+
+func FromContextSingleton[T any](ctx context.Context) *T {
+	var name *T
+	return FromContext[T](ctx, fmt.Sprintf("singleton::%T", name))
+}
+
+func ContextWithValue[T any](ctx context.Context, key string, value *T) context.Context {
+	return context.WithValue(ctx, key, value)
+}
+
+func ContextWithValueSingleton[T any](ctx context.Context, value *T) context.Context {
+	return ContextWithValue(ctx, fmt.Sprintf("singleton::%T", value), value)
+}

--- a/pkg/webutil/auth.go
+++ b/pkg/webutil/auth.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rand"
 	"embed"
 	"encoding/base64"
-	"encoding/gob"
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"io/fs"
@@ -15,8 +15,10 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/go-chi/chi/v5"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
+	"github.com/rebuy-de/rebuy-go-sdk/v5/pkg/cmdutil"
+	"github.com/rebuy-de/rebuy-go-sdk/v5/pkg/logutil"
+	"github.com/rebuy-de/rebuy-go-sdk/v5/pkg/typeutil"
+	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 )
 
@@ -25,15 +27,11 @@ const (
 	authSessionName = `oauth`
 )
 
-// AuthInfo contains data about the currently logged in user.
-type AuthInfo struct {
-	Username  string
-	Name      string
-	Roles     []string
-	UpdatedAt time.Time
+func cookieName() string {
+	return cmdutil.Name + "-token"
 }
 
-type IDTokenClaims struct {
+type AuthInfo struct {
 	Username    string `json:"preferred_username"`
 	Name        string `json:"name"`
 	RealmAccess struct {
@@ -45,7 +43,7 @@ type IDTokenClaims struct {
 // be allowlisted in the AuthMiddleware, otherwise it will return false even if
 // the user is in the team.
 func (i AuthInfo) HasRole(want string) bool {
-	for _, have := range i.Roles {
+	for _, have := range i.RealmAccess.Roles {
 		if have == want {
 			return true
 		}
@@ -54,167 +52,176 @@ func (i AuthInfo) HasRole(want string) bool {
 	return false
 }
 
-func init() {
-	gob.Register(AuthInfo{})
+type authMiddleware struct {
+	getClaimFromRequest     func(*http.Request) (*AuthInfo, error)
+	createTokenFromCallback func(*http.Request) (string, error)
+	handleLogin             func(http.ResponseWriter, *http.Request)
+}
+
+func (m *authMiddleware) handler(next http.Handler) http.Handler {
+	router := chi.NewRouter()
+	router.HandleFunc("/*", func(w http.ResponseWriter, r *http.Request) {
+		claims, err := m.getClaimFromRequest(r)
+		if err != nil {
+			logutil.Get(r.Context()).Warnf("auth middleware: %v", err.Error())
+		} else {
+			ctx := r.Context()
+			ctx = typeutil.ContextWithValueSingleton(ctx, claims)
+			r = r.WithContext(ctx)
+		}
+
+		next.ServeHTTP(w, r)
+	})
+
+	router.HandleFunc("/auth/login", m.handleLogin)
+
+	router.HandleFunc("/auth/callback", func(w http.ResponseWriter, r *http.Request) {
+		token, err := m.createTokenFromCallback(r)
+		if err != nil {
+			fmt.Fprintf(w, "handle callback: %v", err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		cookie := http.Cookie{
+			Name:     cookieName(),
+			Value:    token,
+			Path:     "/",
+			Expires:  time.Now().Add(7 * 24 * time.Hour), // TODO
+			Secure:   true,
+			HttpOnly: true,
+			SameSite: http.SameSiteStrictMode,
+		}
+		http.SetCookie(w, &cookie)
+
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+	})
+
+	return router
+}
+
+type AuthSecrets struct {
+	ClientID     string `vault:"client_id"`
+	ClientSecret string `vault:"client_secret"`
 }
 
 type AuthConfig struct {
-	ClientID     string
-	ClientSecret string
-	ConfigURL    string
-	RedirectURL  string
-	SigningAlgs  []string
+	Secrets     AuthSecrets
+	ConfigURL   string
+	BaseURL     string
+	SigningAlgs []string
 }
 
-// Middleware is an HTTP request middleware that adds login endpoints. The
-// request makes use of sessions, therefore the SessionMiddleware is required.
-//
-// The teams argument contains a whitelist of team names, that are copied into
-// the AuthInfo, if the user is in those teams. It is desirable to copy only
-// the needed subset of teams into the AuthInfo, because this data is carried
-// in the session cookie.
-//
-// Endpoint "/auth/login" initiates the user login and redirects them to the
-// GitHub OAuth page.
-//
-// Endpoint "/auth/callback" gets called by the user after being redirected
-// from GitHub after a successful login.
-func (c AuthConfig) Middleware() func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return c.authMiddlewareFunc(next)
-	}
+func (c *AuthConfig) Bind(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVar(
+		&c.ConfigURL, "oidc-config-url", "",
+		`URL to retrieve the OpenID Provider Configuration Information.`)
+	cmd.PersistentFlags().StringVar(
+		&c.BaseURL, "oidc-base-url", "",
+		`Public reachable URL of this application. Used for cookies and the callback URL.`)
 }
 
-func (c AuthConfig) authMiddlewareFunc(next http.Handler) http.Handler {
-	provider, err := oidc.NewProvider(context.Background(), c.ConfigURL)
+func NewAuthMiddleware(ctx context.Context, config AuthConfig) (func(http.Handler) http.Handler, error) {
+	provider, err := oidc.NewProvider(ctx, config.ConfigURL)
 	if err != nil {
-		logrus.Error(err)
+		return nil, fmt.Errorf("init OIDC provider: %w", err)
 	}
 
 	oidcConfig := &oidc.Config{
-		ClientID:             c.ClientID,
-		SupportedSigningAlgs: c.SigningAlgs,
+		ClientID:             config.Secrets.ClientID,
+		SupportedSigningAlgs: config.SigningAlgs,
 	}
 
-	mw := authMiddleware{
-		next:  next,
-		teams: map[string]struct{}{},
-		config: &oauth2.Config{
-			ClientID:     c.ClientID,
-			ClientSecret: c.ClientSecret,
-			RedirectURL:  c.RedirectURL,
-			Scopes:       []string{oidc.ScopeOpenID, "email", "profile", "roles"},
-			Endpoint:     provider.Endpoint(),
+	oauth2Config := &oauth2.Config{
+		ClientID:     config.Secrets.ClientID,
+		ClientSecret: config.Secrets.ClientSecret,
+		RedirectURL:  strings.TrimRight(config.BaseURL, "/") + "/auth/callback",
+		Scopes:       []string{oidc.ScopeOpenID, "email", "roles"},
+		Endpoint:     provider.Endpoint(),
+	}
+
+	verifier := provider.Verifier(oidcConfig)
+
+	m := authMiddleware{
+		handleLogin: func(w http.ResponseWriter, r *http.Request) {
+			oauthState := generateCookie(w)
+			u := oauth2Config.AuthCodeURL(oauthState)
+			http.Redirect(w, r, u, http.StatusTemporaryRedirect)
 		},
-		verifier: provider.Verifier(oidcConfig),
+		getClaimFromRequest: func(r *http.Request) (*AuthInfo, error) {
+			cookie, err := r.Cookie(cookieName())
+			if err != nil {
+				return nil, fmt.Errorf("get auth cookie")
+			}
+
+			idToken, err := verifier.Verify(r.Context(), cookie.Value)
+			if err != nil {
+				return nil, fmt.Errorf("verify token: %w", err)
+			}
+
+			var authInfo AuthInfo
+			err = idToken.Claims(&authInfo)
+			if err != nil {
+				return nil, fmt.Errorf("unmarshal claims: %w", err)
+			}
+
+			return &authInfo, nil
+		},
+		createTokenFromCallback: func(r *http.Request) (string, error) {
+			oauthState, err := r.Cookie(authStateCookie)
+			if err != nil {
+				return "", fmt.Errorf("get auth cookie: %w", err)
+			}
+
+			if r.FormValue("state") != oauthState.Value {
+				return "", fmt.Errorf("invalid oauth state cookie")
+			}
+
+			token, err := oauth2Config.Exchange(r.Context(), r.FormValue("code"))
+			if err != nil {
+				return "", fmt.Errorf("exchange token: %w", err)
+			}
+
+			rawIDToken, ok := token.Extra("id_token").(string)
+			if !ok {
+				return "", fmt.Errorf("no id_token field in oauth2 token")
+			}
+
+			idToken, err := verifier.Verify(r.Context(), rawIDToken)
+			if err != nil {
+				return "", fmt.Errorf("verify token: %w", err)
+			}
+
+			var claims AuthInfo
+			err = idToken.Claims(&claims)
+			if err != nil {
+				return "", fmt.Errorf("unmarshal claims: %w", err)
+			}
+
+			return rawIDToken, nil
+		},
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/auth/login", mw.handleLogin)
-	mux.HandleFunc("/auth/callback", mw.handleCallback)
-	mux.HandleFunc("/", mw.handleDefault)
-
-	return mux
+	return m.handler, nil
 }
 
-type authMiddleware struct {
-	next     http.Handler
-	teams    map[string]struct{}
-	config   *oauth2.Config
-	verifier *oidc.IDTokenVerifier
-}
-
-func (mw *authMiddleware) handleDefault(w http.ResponseWriter, r *http.Request) {
-	mw.next.ServeHTTP(w, r)
-}
-
-func (mw *authMiddleware) handleLogin(w http.ResponseWriter, r *http.Request) {
-	oauthState := mw.generateCookie(w)
-	u := mw.config.AuthCodeURL(oauthState)
-	http.Redirect(w, r, u, http.StatusTemporaryRedirect)
-}
-
-func (mw *authMiddleware) generateCookie(w http.ResponseWriter) string {
+func generateCookie(w http.ResponseWriter) string {
 	var expiration = time.Now().Add(10 * time.Minute)
 
 	b := make([]byte, 16)
 	rand.Read(b)
 	state := base64.URLEncoding.EncodeToString(b)
 	cookie := http.Cookie{
-		Name:    authStateCookie,
-		Value:   state,
-		Expires: expiration,
+		Name:     authStateCookie,
+		Value:    state,
+		Expires:  expiration,
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
 	}
 	http.SetCookie(w, &cookie)
 
 	return state
-}
-
-func (mw *authMiddleware) handleCallback(w http.ResponseWriter, r *http.Request) {
-	oauthState, err := r.Cookie(authStateCookie)
-	if err != nil {
-		logrus.WithError(errors.WithStack(err)).Error("failed get auth cookie")
-		return
-	}
-
-	if r.FormValue("state") != oauthState.Value {
-		logrus.Warn("invalid oauth state")
-		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
-		return
-	}
-
-	token, err := mw.config.Exchange(context.Background(), r.FormValue("code"))
-	if err != nil {
-		logrus.WithError(errors.WithStack(err)).Error("failed to exchange token")
-		return
-	}
-
-	rawIDToken, ok := token.Extra("id_token").(string)
-	if !ok {
-		logrus.WithError(errors.WithStack(err)).Error("No id_token field in oauth2 token")
-		return
-	}
-
-	idToken, err := mw.verifier.Verify(r.Context(), rawIDToken)
-	if err != nil {
-		logrus.WithError(errors.WithStack(err)).Error("Failed to verify ID Token: " + err.Error())
-		return
-	}
-
-	var claims IDTokenClaims
-	err = idToken.Claims(&claims)
-	if err != nil {
-		logrus.WithError(errors.WithStack(err)).Error("Failed to unmarshal claims: " + err.Error())
-		return
-	}
-
-	refreshSessionData(w, r, &claims)
-	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
-}
-
-func refreshSessionData(w http.ResponseWriter, r *http.Request, idTokenClaims *IDTokenClaims) error {
-	session, err := SessionFromRequest(r)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	info, ok := session.Values["auth-info"].(AuthInfo)
-	if !ok {
-		info = AuthInfo{}
-	}
-
-	info.Username = idTokenClaims.Username
-	info.Name = idTokenClaims.Name
-	info.UpdatedAt = time.Now()
-	info.Roles = idTokenClaims.RealmAccess.Roles
-
-	session.Values["auth-info"] = info
-	err = session.Save(r, w)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	return nil
 }
 
 //go:embed templates/*
@@ -233,20 +240,35 @@ func DevAuthMiddleware(roles ...string) func(http.Handler) http.Handler {
 		roleNames[fmt.Sprintf("role-%s", r)] = r
 	}
 
-	return func(next http.Handler) http.Handler {
-		router := chi.NewRouter()
-		router.HandleFunc("/*", next.ServeHTTP)
-
-		router.Get("/auth/login", vh.Wrap(func(v *View, r *http.Request) Response {
+	m := authMiddleware{
+		handleLogin: vh.Wrap(func(v *View, r *http.Request) Response {
 			return v.HTML(http.StatusOK, "dev-login.html", map[string]any{
 				"username": "dummy@example.com",
 				"name":     "John Doe",
 				"roles":    roleNames,
 			})
-		}))
+		}),
+		getClaimFromRequest: func(r *http.Request) (*AuthInfo, error) {
+			cookie, err := r.Cookie(cookieName())
+			if err != nil {
+				return nil, fmt.Errorf("get cookie: %w", err)
+			}
 
-		router.Post("/auth/login", func(w http.ResponseWriter, r *http.Request) {
-			var claims IDTokenClaims
+			jsonPayload, err := base64.RawURLEncoding.DecodeString(cookie.Value)
+			if err != nil {
+				return nil, fmt.Errorf("b64 decode cookie: %w", err)
+			}
+
+			var claims AuthInfo
+			err = json.Unmarshal(jsonPayload, &claims)
+			if err != nil {
+				return nil, fmt.Errorf("json decode cookie: %w", err)
+			}
+
+			return &claims, nil
+		},
+		createTokenFromCallback: func(r *http.Request) (string, error) {
+			var claims AuthInfo
 
 			claims.Username = r.PostFormValue("username")
 			claims.Name = r.PostFormValue("name")
@@ -258,12 +280,18 @@ func DevAuthMiddleware(roles ...string) func(http.Handler) http.Handler {
 				}
 			}
 
-			refreshSessionData(w, r, &claims)
-			http.Redirect(w, r, "/", http.StatusSeeOther)
-		})
+			jsonPayload, err := json.Marshal(claims)
+			if err != nil {
+				return "", fmt.Errorf("marshal cookie: %v", err)
+			}
 
-		return router
+			b64Payload := base64.RawURLEncoding.EncodeToString(jsonPayload)
+
+			return string(b64Payload), nil
+		},
 	}
+
+	return m.handler
 }
 
 // AuthTemplateFunctions returns auth related template functions.  These can
@@ -285,8 +313,8 @@ func DevAuthMiddleware(roles ...string) func(http.Handler) http.Handler {
 //	{{ end }}
 func AuthTemplateFunctions(r *http.Request) template.FuncMap {
 	authenticated := true
-	info, err := AuthInfoFromRequest(r)
-	if err != nil {
+	info := AuthInfoFromRequest(r)
+	if info == nil {
 		authenticated = false
 	}
 
@@ -303,24 +331,14 @@ func AuthTemplateFunctions(r *http.Request) template.FuncMap {
 // AuthInfoFromContext extracts the AuthInfo from the given context. The
 // AuthInfo is injected into the request via the AuthMiddleware. Therefore it
 // is required to use this middleware to be able to get the AuthInfo.
-func AuthInfoFromContext(ctx context.Context) (*AuthInfo, error) {
-	sess, err := SessionFromContext(ctx)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	info, ok := sess.Values["auth-info"].(AuthInfo)
-	if !ok {
-		return nil, errors.Errorf("auth info not found in context")
-	}
-
-	return &info, nil
+func AuthInfoFromContext(ctx context.Context) *AuthInfo {
+	return typeutil.FromContextSingleton[AuthInfo](ctx)
 }
 
 // AuthInfoFromRequest extracts the AuthInfo from the context within the given
 // request. The AuthInfo is injected into the request via the AuthMiddleware.
 // Therefore it is required to use this middleware to be able to get the
 // AuthInfo.
-func AuthInfoFromRequest(r *http.Request) (*AuthInfo, error) {
+func AuthInfoFromRequest(r *http.Request) *AuthInfo {
 	return AuthInfoFromContext(r.Context())
 }

--- a/pkg/webutil/templates/dev-login.html
+++ b/pkg/webutil/templates/dev-login.html
@@ -43,7 +43,7 @@
   </head>
   <body>
     <h1>SDK Dev Login</h1>
-    <form method="post">
+    <form method="post" action="/auth/callback">
       <div>
         <label for="input-username">Username</label>
         <input id="input-username" name="username" value="{{.username}}">


### PR DESCRIPTION
Copy code that was already used in keydb-inspector. Key changes:

* The normal and the dev middlewares for auth now use the same codebase. Each one just defines a set of function (`handleLogin`, `getClaimFromRequest` and `createTokenFromCallback`). This way the dev command is closer to production.
* Merge `IDTokenClaims` and `AuthInfo`.