### PR TITLE
fix strict mode for session cookie

### DIFF
--- a/pkg/webutil/auth.go
+++ b/pkg/webutil/auth.go
@@ -90,7 +90,7 @@ func (m *authMiddleware) handler(next http.Handler) http.Handler {
 			Expires:  time.Now().Add(7 * 24 * time.Hour), // TODO
 			Secure:   true,
 			HttpOnly: true,
-			SameSite: http.SameSiteStrictMode,
+			SameSite: http.SameSiteLaxMode,
 		}
 		http.SetCookie(w, &cookie)
 


### PR DESCRIPTION
This is the same issue which we had with the Graylog login. Essentially not being logged in, when entering the website from another domain.

Because this essentially breaks the login feature, I will to a patch release.
