### PR TITLE
make buildutil compatible with 'go work'

### DIFF
--- a/buildutil
+++ b/buildutil
@@ -2,4 +2,4 @@
 set -eu
 go mod vendor
 go generate ./...
-exec go run github.com/rebuy-de/rebuy-go-sdk/v6/cmd/buildutil "$@"
+exec go run ./cmd/buildutil "$@"

--- a/cmd/buildutil/info.go
+++ b/cmd/buildutil/info.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rebuy-de/rebuy-go-sdk/v6/pkg/cmdutil"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/mod/modfile"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -210,6 +211,20 @@ type TargetInfo struct {
 	PGO     string
 }
 
+func ReadGoMod() (*modfile.File, error) {
+	data, err := os.ReadFile("go.mod")
+	if err != nil {
+		return nil, fmt.Errorf("read go.mod file: %w", err)
+	}
+
+	file, err := modfile.Parse("go.mod", data, nil)
+	if err != nil {
+		return nil, fmt.Errorf("parse go.mod file: %w", err)
+	}
+
+	return file, nil
+}
+
 func CollectBuildInformation(ctx context.Context, p BuildParameters) (BuildInfo, error) {
 	var (
 		err  error
@@ -220,11 +235,20 @@ func CollectBuildInformation(ctx context.Context, p BuildParameters) (BuildInfo,
 
 	logrus.Info("Collecting build information")
 
+	gomod, err := ReadGoMod()
+	if err != nil {
+		return info, err
+	}
+
+	info.Go.Module = gomod.Module.Mod.Path
+	info.Go.Dir, err = os.Getwd()
+	if err != nil {
+		return info, err
+	}
+
 	e := NewChainExecutor(ctx)
 
 	info.BuildDate = time.Now().Format(time.RFC3339)
-	info.Go.Module = e.OutputString(p.GoCommand, "list")
-	info.Go.Dir = e.OutputString(p.GoCommand, "list", "-f", "{{.Dir}}")
 	info.System.OS = e.OutputString(p.GoCommand, "env", "GOOS")
 	info.System.Arch = e.OutputString(p.GoCommand, "env", "GOARCH")
 	info.System.Ext = e.OutputString(p.GoCommand, "env", "GOEXE")

--- a/cmd/buildutil/info.go
+++ b/cmd/buildutil/info.go
@@ -223,8 +223,8 @@ func CollectBuildInformation(ctx context.Context, p BuildParameters) (BuildInfo,
 	e := NewChainExecutor(ctx)
 
 	info.BuildDate = time.Now().Format(time.RFC3339)
-	info.Go.Module = e.OutputString(p.GoCommand, "list", "-m", "-mod=mod")
-	info.Go.Dir = e.OutputString(p.GoCommand, "list", "-m", "-mod=mod", "-f", "{{.Dir}}")
+	info.Go.Module = e.OutputString(p.GoCommand, "list")
+	info.Go.Dir = e.OutputString(p.GoCommand, "list", "-f", "{{.Dir}}")
 	info.System.OS = e.OutputString(p.GoCommand, "env", "GOOS")
 	info.System.Arch = e.OutputString(p.GoCommand, "env", "GOARCH")
 	info.System.Ext = e.OutputString(p.GoCommand, "env", "GOEXE")

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/tidwall/pretty v1.2.1
 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
+	golang.org/x/mod v0.14.0
 	golang.org/x/oauth2 v0.16.0
 	golang.org/x/sync v0.6.0
 	golang.org/x/tools v0.17.0
@@ -136,7 +137,6 @@ require (
 	github.com/yuin/gopher-lua v1.1.0 // indirect
 	gitlab.com/digitalxero/go-conventional-commit v1.0.7 // indirect
 	golang.org/x/crypto v0.18.0 // indirect
-	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/term v0.16.0 // indirect


### PR DESCRIPTION
Fixes this error.

```
INFO[0000] Collecting build information
go: -mod may only be set to readonly when in workspace mode, but it is set to "mod"
	Remove the -mod flag to use the default readonly value,
	or set GOWORK=off to disable workspace mode.
ERRO[0000] failed to run `go list -m -mod=mod`: exit status 1
```

I think the flags are not needed anymore, because go modules are the default now.
