### PR TITLE
add digutil

### DIFF
--- a/pkg/digutil/types.go
+++ b/pkg/digutil/types.go
@@ -1,0 +1,14 @@
+package digutil
+
+import "go.uber.org/dig"
+
+type Optional[T any] struct {
+	dig.In
+	Value *T `optional:"true"`
+}
+
+func ProvideValue[T any](c *dig.Container, v T) error {
+	return c.Provide(func() T {
+		return v
+	})
+}


### PR DESCRIPTION
Adds digutil package with two helpers, which are often needed for setting up containers and workers.
