### PR TITLE
add no-format variant of webutil.ViewRedirect

### DIFF
--- a/pkg/webutil/viewfuncs.go
+++ b/pkg/webutil/viewfuncs.go
@@ -11,12 +11,18 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// WrapView converts a function that returns a Response into an http.HandlerFunc.
+// This allows for a more functional approach to HTTP handling where the handler
+// logic can be separated from the actual response writing.
 func WrapView(fn func(*http.Request) Response) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		fn(r)(w, r)
 	}
 }
 
+// ViewError returns an http.HandlerFunc that writes an error response with the given HTTP status code.
+// It also logs the error with appropriate severity based on the status code.
+// If the error is a context.Canceled error, it changes the status code to 499 (client closed connection).
 func ViewError(status int, err error) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		l := logrus.
@@ -42,17 +48,23 @@ func ViewError(status int, err error) http.HandlerFunc {
 	}
 }
 
-func ViewErrorf(status int, text string, a ...interface{}) http.HandlerFunc {
-	return ViewError(status, fmt.Errorf(text, a...))
+// ViewRedirectf returns an http.HandlerFunc that redirects to the formatted location string.
+// It uses fmt.Sprintf to format the location with the provided arguments.
+func ViewRedirectf(status int, location string, args ...any) http.HandlerFunc {
+	return ViewRedirect(status, fmt.Sprintf(location, args...))
 }
 
-func ViewRedirect(status int, location string, args ...interface{}) http.HandlerFunc {
+// ViewRedirect returns an http.HandlerFunc that performs an HTTP redirect to the specified location.
+// The status parameter should be an appropriate HTTP redirection status code (e.g., 301, 302, 303).
+func ViewRedirect(status int, location string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		url := fmt.Sprintf(location, args...)
-		http.Redirect(w, r, url, status)
+		http.Redirect(w, r, location, status)
 	}
 }
 
+// ViewJSON returns an http.HandlerFunc that writes the provided data as indented JSON.
+// It sets the Content-Type header to application/json and the provided status code.
+// If encoding fails, it responds with an internal server error.
 func ViewJSON(status int, data any) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		buf := new(bytes.Buffer)
@@ -71,6 +83,9 @@ func ViewJSON(status int, data any) http.HandlerFunc {
 	}
 }
 
+// ViewInlineHTML returns an http.HandlerFunc that writes the provided HTML string with formatting.
+// It sets the Content-Type header to text/html and the specified status code.
+// The format string and arguments are passed to fmt.Fprintf for rendering.
 func ViewInlineHTML(status int, data string, a ...any) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -79,6 +94,8 @@ func ViewInlineHTML(status int, data string, a ...any) http.HandlerFunc {
 	}
 }
 
+// ViewNoContent returns an http.HandlerFunc that writes only a status code with no response body.
+// This is useful for endpoints that need to return a success or error status without content.
 func ViewNoContent(status int) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(status)


### PR DESCRIPTION
We need a second function to avoid the `non-constant format string in call` error in Go 1.24, when calling without
formatting options.

Also added some docs for the view functions.
