### PR TITLE
add positional args to runner

### DIFF
--- a/cmd/buildutil/runner.go
+++ b/cmd/buildutil/runner.go
@@ -91,7 +91,7 @@ func (r *Runner) dist(parts ...string) string {
 	return path.Join(parts...)
 }
 
-func (r *Runner) Run(ctx context.Context) error {
+func (r *Runner) Run(ctx context.Context, _ []string) error {
 	defer r.Inst.Durations.Steps.Stopwatch("all")()
 
 	return runSeq(ctx,

--- a/examples/full/cmd/root.go
+++ b/examples/full/cmd/root.go
@@ -51,7 +51,7 @@ func (r *DaemonRunner) Bind(cmd *cobra.Command) error {
 	return nil
 }
 
-func (r *DaemonRunner) Run(ctx context.Context) error {
+func (r *DaemonRunner) Run(ctx context.Context, _ []string) error {
 	c := dig.New()
 
 	err := errors.Join(
@@ -87,7 +87,7 @@ func (r *DevRunner) Bind(cmd *cobra.Command) error {
 	return nil
 }
 
-func (r *DevRunner) Run(ctx context.Context) error {
+func (r *DevRunner) Run(ctx context.Context, _ []string) error {
 	c := dig.New()
 
 	redisAddress := r.redisAddress

--- a/examples/minimal/cmd/root.go
+++ b/examples/minimal/cmd/root.go
@@ -31,7 +31,7 @@ func (r *Runner) Bind(cmd *cobra.Command) error {
 	return nil
 }
 
-func (r *Runner) Run(ctx context.Context) error {
+func (r *Runner) Run(ctx context.Context, _ []string) error {
 	fmt.Printf("Hello %s!\n", r.name)
 	return nil
 }

--- a/migrations.md
+++ b/migrations.md
@@ -14,6 +14,8 @@ Check release notes and upgrade to v9.
 * `webutil.ViewRedirect` does not support format args anymore. Use `webutil.ViewRedirectf` instead.
 * `webutil.AdminAPIListenAndServe` now uses options. Check go docs for new usage.
 * Removed `cdnmirror`. Use Yarn or similar instead.
+* Change signature of `cmdutil.Runner.Run` from `(context.Context)` to `(context.Context, []string)` in order to be able
+  to access positional args.
 
 
 ## M0007 2024-11-08 Switch to Dependency Injection

--- a/pkg/cmdutil/command.go
+++ b/pkg/cmdutil/command.go
@@ -65,7 +65,7 @@ func WithSubCommand(sub *cobra.Command) Option {
 // Binder defines the interface used by the generic [WithRun] function.
 type Runner interface {
 	Bind(*cobra.Command) error
-	Run(context.Context) error
+	Run(context.Context, []string) error
 }
 
 // WithRunner that accepts a generic type which must implement the [Binder]
@@ -77,7 +77,7 @@ func WithRunner(runner Runner) Option {
 
 		cmd.Run = func(cmd *cobra.Command, args []string) {
 			ctx := SignalRootContext()
-			err := runner.Run(ctx)
+			err := runner.Run(ctx, args)
 			must(err)
 		}
 		return nil


### PR DESCRIPTION
Needed, since we removed cmdutil.WithRun. I it a little bit polluting, since we are not using positional args in most projects, but it is still the cleanest solution.
