### PR TITLE
Use net.JoinHostPort to construct listen address

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.36.2
 	github.com/aws/aws-sdk-go-v2/config v1.29.7
 	github.com/coreos/go-oidc/v3 v3.12.0
-	github.com/evanw/esbuild v0.25.0
 	github.com/gemnasium/logrus-graylog-hook/v3 v3.2.1
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,6 @@ github.com/ebitengine/purego v0.7.1 h1:6/55d26lG3o9VCZX8lping+bZcmShseiqlh2bnUDi
 github.com/ebitengine/purego v0.7.1/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
 github.com/emicklei/go-restful/v3 v3.12.1 h1:PJMDIM/ak7btuL8Ex0iYET9hxM3CI2sjZtzpL63nKAU=
 github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/evanw/esbuild v0.25.0 h1:jRR9D1pfdb669VzdN4w0jwsDfrKE098nKMaDMKvMPyU=
-github.com/evanw/esbuild v0.25.0/go.mod h1:D2vIQZqV/vIf/VRHtViaUtViZmG7o+kKmlBfVQuRi48=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=

--- a/pkg/webutil/admin.go
+++ b/pkg/webutil/admin.go
@@ -3,13 +3,14 @@ package webutil
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/pprof"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rebuy-de/rebuy-go-sdk/v9/pkg/logutil"
 
-    // instutil import ensures the init function of that package is run, which adds the toolstack metrics
+	// instutil import ensures the init function of that package is run, which adds the toolstack metrics
 	_ "github.com/rebuy-de/rebuy-go-sdk/v9/pkg/instutil"
 )
 
@@ -73,9 +74,11 @@ func AdminAPIListenAndServe(ctx context.Context, opts ...AdminAPIListenAndServeO
 	bg := context.Background()
 
 	go func() {
-		logutil.Get(ctx).Debugf("admin api listening on port %s", config.port)
+		serverAddress := net.JoinHostPort(config.host, config.port)
 
-		err := ListenAndServeWithContext(bg, fmt.Sprintf("%s:%s", config.host, config.port), mux)
+		logutil.Get(ctx).Debugf("admin api listening on %s", serverAddress)
+
+		err := ListenAndServeWithContext(bg, serverAddress, mux)
 		if err != nil {
 			logutil.Get(ctx).Error(err.Error())
 		}


### PR DESCRIPTION
Just stumbled over this in the Go 1.25 changelogs - you can't use the `Sprintf` method with IPv6 addresses, so there's a special `net.JoinHostPort` function for this that's better suited.
https://tip.golang.org/doc/go1.25#vet