### PR TITLE
add Coalesce and Zero utility functions to typeutil

### DIFF
--- a/pkg/typeutil/pointer.go
+++ b/pkg/typeutil/pointer.go
@@ -13,10 +13,34 @@ func Pointer[T any](v T) *T {
 // Value returns the value from a pointer. If the pointer is nil, it will
 // return the zero value instead.
 func Value[T any](p *T) T {
-	if p != nil {
-		return *p
+	return Coalesce(Zero[T](), p)
+}
+
+// Coalesce returns the value of the first non-nil pointer from the given
+// list of pointers. If all pointers are nil, it returns the fallback value.
+// This is useful for providing default values when working with optional
+// pointer fields, allowing you to chain multiple fallback options.
+func Coalesce[T any](fallback T, pointer ...*T) T {
+	for _, p := range pointer {
+		if p != nil {
+			return *p
+		}
 	}
 
+	return fallback
+}
+
+// CoalesceZero returns the value of the first non-nil pointer from the given
+// list of pointers. If all pointers are nil, it returns the zero value for
+// type T. This is a convenience wrapper around Coalesce that uses the zero
+// value as the fallback.
+func CoalesceZero[T any](pointers ...*T) T {
+	return Coalesce(Zero[T](), pointers...)
+}
+
+// Zero returns the zero value for type T. This is useful when you need to
+// explicitly reference a zero value in generic code.
+func Zero[T any]() T {
 	var zero T
 	return zero
 }

--- a/pkg/typeutil/pointer_test.go
+++ b/pkg/typeutil/pointer_test.go
@@ -1,0 +1,174 @@
+package typeutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPointer(t *testing.T) {
+	cases := []struct {
+		Name     string
+		TestFunc func(t *testing.T)
+	}{
+		{
+			Name: "Int",
+			TestFunc: func(t *testing.T) {
+				value := 42
+				ptr := Pointer(value)
+				require.NotNil(t, ptr)
+				require.Equal(t, value, *ptr)
+			},
+		},
+		{
+			Name: "String",
+			TestFunc: func(t *testing.T) {
+				value := "hello"
+				ptr := Pointer(value)
+				require.NotNil(t, ptr)
+				require.Equal(t, value, *ptr)
+			},
+		},
+		{
+			Name: "Struct",
+			TestFunc: func(t *testing.T) {
+				type TestStruct struct {
+					X int
+					Y string
+				}
+				value := TestStruct{X: 10, Y: "test"}
+				ptr := Pointer(value)
+				require.NotNil(t, ptr)
+				require.Equal(t, value, *ptr)
+			},
+		},
+		{
+			Name: "ZeroValue",
+			TestFunc: func(t *testing.T) {
+				// Test with zero values for different types
+				intPtr := Pointer(0)
+				require.NotNil(t, intPtr)
+				require.Equal(t, 0, *intPtr)
+
+				strPtr := Pointer("")
+				require.NotNil(t, strPtr)
+				require.Equal(t, "", *strPtr)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, tc.TestFunc)
+	}
+}
+
+func TestValue(t *testing.T) {
+	cases := []struct {
+		Name  string
+		Input *int
+		Want  int
+	}{
+		{
+			Name:  "NonNil",
+			Input: Pointer(42),
+			Want:  42,
+		},
+		{
+			Name:  "Nil",
+			Input: nil,
+			Want:  0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			have := Value(tc.Input)
+			require.Equal(t, tc.Want, have)
+		})
+	}
+}
+
+func TestValueString(t *testing.T) {
+	cases := []struct {
+		Name  string
+		Input *string
+		Want  string
+	}{
+		{
+			Name:  "NonNil",
+			Input: Pointer("hello"),
+			Want:  "hello",
+		},
+		{
+			Name:  "Nil",
+			Input: nil,
+			Want:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			have := Value(tc.Input)
+			require.Equal(t, tc.Want, have)
+		})
+	}
+}
+
+func TestCoalesce(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Fallback int
+		Pointers []*int
+		Want     int
+	}{
+		{
+			Name:     "FirstNonNil",
+			Fallback: 0,
+			Pointers: []*int{Pointer(1), Pointer(2), Pointer(3)},
+			Want:     1,
+		},
+		{
+			Name:     "SecondNonNil",
+			Fallback: 0,
+			Pointers: []*int{nil, Pointer(2), Pointer(3)},
+			Want:     2,
+		},
+		{
+			Name:     "AllNil",
+			Fallback: 99,
+			Pointers: []*int{nil, nil, nil},
+			Want:     99,
+		},
+		{
+			Name:     "NoPointers",
+			Fallback: 42,
+			Pointers: []*int{},
+			Want:     42,
+		},
+		{
+			Name:     "SingleNonNil",
+			Fallback: 0,
+			Pointers: []*int{Pointer(5)},
+			Want:     5,
+		},
+		{
+			Name:     "SingleNil",
+			Fallback: 10,
+			Pointers: []*int{nil},
+			Want:     10,
+		},
+		{
+			Name:     "MixedWithZeroValue",
+			Fallback: -1,
+			Pointers: []*int{nil, Pointer(0), Pointer(1)},
+			Want:     0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			have := Coalesce(tc.Fallback, tc.Pointers...)
+			require.Equal(t, tc.Want, have)
+		})
+	}
+}


### PR DESCRIPTION
This adds three new utility functions to the pointer package:
- Coalesce: returns the first non-nil pointer value or a fallback
- CoalesceZero: convenience wrapper using zero value as fallback
- Zero: explicitly returns the zero value for a type

The Value function has been refactored to use Coalesce internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
