### PR TITLE
add Prometheus health monitoring to runutil workers

### DIFF
--- a/pkg/runutil/declarative.go
+++ b/pkg/runutil/declarative.go
@@ -18,6 +18,14 @@ type DeclarativeWorker struct {
 func (w DeclarativeWorker) Run(ctx context.Context) error {
 	worker := w.Worker
 
+	// Register health monitor in "init" state as soon as worker starts.
+	// Placed innermost so the full subsystem path is available.
+	inner := worker
+	worker = WorkerFunc(func(ctx context.Context) error {
+		GetHealthMonitor(ctx)
+		return inner.Run(ctx)
+	})
+
 	if w.Name != "" {
 		worker = NamedWorker(worker, w.Name)
 	}

--- a/pkg/runutil/distributed_repeat.go
+++ b/pkg/runutil/distributed_repeat.go
@@ -123,6 +123,8 @@ func (r *DistributedRepeat) runOnce(ctx context.Context) error {
 		tracer.Tag(ext.ResourceName, logutil.GetSubsystem(ctx)),
 	)
 	err := r.job.RunOnce(ctx)
+	HealthCheckpoint(ctx, err)
+
 	if err != nil {
 		span.Finish(tracer.WithError(err))
 		return err

--- a/pkg/runutil/health.go
+++ b/pkg/runutil/health.go
@@ -1,0 +1,152 @@
+package runutil
+
+import (
+	"context"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/rebuy-de/rebuy-go-sdk/v9/pkg/logutil"
+)
+
+const (
+	promNamespace       = "rebuy_go_sdk"
+	promHealthSubsystem = "health"
+)
+
+const (
+	HealthStateInit   = "init"
+	HealthStateOK     = "ok"
+	HealthStateFiring = "firing"
+)
+
+var (
+	instHealthCheckpointsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promHealthSubsystem,
+		Name:      "checkpoints_total",
+	}, []string{"name", "state"})
+
+	instHealthState = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: promNamespace,
+		Subsystem: promHealthSubsystem,
+		Name:      "state",
+	}, []string{"name", "state"})
+)
+
+var healthRegistry = &healthRegistryImpl{
+	monitors: map[string]*healthMonitor{},
+}
+
+// HealthMonitor tracks the health state of a worker via Prometheus metrics.
+type HealthMonitor interface {
+	Checkpoint(err error)
+}
+
+// HealthCheckpoint records a health checkpoint for the current subsystem.
+// It is a no-op if the context has no subsystem set.
+func HealthCheckpoint(ctx context.Context, err error) {
+	name := logutil.GetSubsystem(ctx)
+	if name == "" {
+		return
+	}
+
+	healthRegistry.get(name).Checkpoint(err)
+}
+
+// GetHealthMonitor returns the health monitor for the current subsystem.
+// Useful for long-running workers that need to pass a monitor to helpers.
+func GetHealthMonitor(ctx context.Context) HealthMonitor {
+	name := logutil.GetSubsystem(ctx)
+	if name == "" {
+		return (*healthMonitor)(nil)
+	}
+
+	return healthRegistry.get(name)
+}
+
+type healthRegistryImpl struct {
+	monitors map[string]*healthMonitor
+	mu       sync.Mutex
+}
+
+func (r *healthRegistryImpl) get(name string) *healthMonitor {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	monitor, ok := r.monitors[name]
+	if !ok {
+		monitor = newHealthMonitor(name)
+		r.monitors[name] = monitor
+	}
+
+	return monitor
+}
+
+func newHealthMonitor(name string) *healthMonitor {
+	m := &healthMonitor{
+		name: name,
+	}
+
+	for _, state := range []string{HealthStateInit, HealthStateOK, HealthStateFiring} {
+		// Register zero values immediately to avoid null values in Prometheus.
+		instHealthCheckpointsTotal.
+			WithLabelValues(name, state).
+			Add(0)
+		instHealthState.
+			WithLabelValues(name, state).
+			Set(0)
+	}
+
+	instHealthState.
+		WithLabelValues(name, HealthStateInit).
+		Set(1)
+
+	return m
+}
+
+type healthMonitor struct {
+	name string
+}
+
+func (m *healthMonitor) Checkpoint(err error) {
+	if m == nil {
+		return
+	}
+
+	if err == nil {
+		m.resolve()
+	} else {
+		m.fire()
+	}
+}
+
+func (m *healthMonitor) resolve() {
+	instHealthCheckpointsTotal.
+		WithLabelValues(m.name, HealthStateOK).
+		Add(1)
+	instHealthState.
+		WithLabelValues(m.name, HealthStateInit).
+		Set(0)
+	instHealthState.
+		WithLabelValues(m.name, HealthStateOK).
+		Set(1)
+	instHealthState.
+		WithLabelValues(m.name, HealthStateFiring).
+		Set(0)
+}
+
+func (m *healthMonitor) fire() {
+	instHealthCheckpointsTotal.
+		WithLabelValues(m.name, HealthStateFiring).
+		Add(1)
+	instHealthState.
+		WithLabelValues(m.name, HealthStateInit).
+		Set(0)
+	instHealthState.
+		WithLabelValues(m.name, HealthStateOK).
+		Set(0)
+	instHealthState.
+		WithLabelValues(m.name, HealthStateFiring).
+		Set(1)
+}

--- a/pkg/runutil/health_test.go
+++ b/pkg/runutil/health_test.go
@@ -1,0 +1,78 @@
+package runutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rebuy-de/rebuy-go-sdk/v9/pkg/logutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHealthRegistry_ReturnsSameMonitor(t *testing.T) {
+	r := &healthRegistryImpl{
+		monitors: map[string]*healthMonitor{},
+	}
+
+	m1 := r.get("test-worker")
+	m2 := r.get("test-worker")
+
+	assert.Same(t, m1, m2)
+}
+
+func TestHealthRegistry_DifferentNames(t *testing.T) {
+	r := &healthRegistryImpl{
+		monitors: map[string]*healthMonitor{},
+	}
+
+	m1 := r.get("worker-a")
+	m2 := r.get("worker-b")
+
+	assert.NotSame(t, m1, m2)
+}
+
+func TestHealthCheckpoint_NoopWithEmptySubsystem(t *testing.T) {
+	ctx := context.Background()
+
+	// Should not panic or create any monitor.
+	HealthCheckpoint(ctx, nil)
+	HealthCheckpoint(ctx, errors.New("test"))
+}
+
+func TestHealthCheckpoint_WithSubsystem(t *testing.T) {
+	ctx := logutil.Start(context.Background(), "test-checkpoint")
+
+	// Should not panic.
+	HealthCheckpoint(ctx, nil)
+	HealthCheckpoint(ctx, errors.New("test"))
+}
+
+func TestGetHealthMonitor_WithSubsystem(t *testing.T) {
+	ctx := logutil.Start(context.Background(), "test-monitor")
+
+	m := GetHealthMonitor(ctx)
+	assert.NotNil(t, m)
+
+	// Calling again should return the same instance.
+	m2 := GetHealthMonitor(ctx)
+	assert.Equal(t, m, m2)
+}
+
+func TestGetHealthMonitor_WithoutSubsystem(t *testing.T) {
+	ctx := context.Background()
+
+	m := GetHealthMonitor(ctx)
+
+	// Returns a nil *healthMonitor which is still a valid HealthMonitor.
+	// Checkpoint should be a no-op.
+	m.Checkpoint(nil)
+	m.Checkpoint(errors.New("test"))
+}
+
+func TestHealthMonitor_NilCheckpoint(t *testing.T) {
+	var m *healthMonitor
+
+	// Should not panic.
+	m.Checkpoint(nil)
+	m.Checkpoint(errors.New("test"))
+}

--- a/pkg/runutil/repeat.go
+++ b/pkg/runutil/repeat.go
@@ -71,6 +71,8 @@ func (w jobWorker) runOnce(ctx context.Context) error {
 		tracer.Tag(ext.ResourceName, logutil.GetSubsystem(ctx)),
 	)
 	err := w.job.RunOnce(ctx)
+	HealthCheckpoint(ctx, err)
+
 	if err != nil {
 		span.Finish(tracer.WithError(err))
 		return err


### PR DESCRIPTION
Tracks worker health state (init/ok/firing) via gauges and checkpoint
counters, integrated automatically into Repeat, DistributedRepeat, and
DeclarativeWorker.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
