### PR TITLE
PF-3963 change health monitor label

### DIFF
--- a/pkg/runutil/health.go
+++ b/pkg/runutil/health.go
@@ -25,13 +25,13 @@ var (
 		Namespace: promNamespace,
 		Subsystem: promHealthSubsystem,
 		Name:      "checkpoints_total",
-	}, []string{"name", "state"})
+	}, []string{"worker_name", "state"})
 
 	instHealthState = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: promNamespace,
 		Subsystem: promHealthSubsystem,
 		Name:      "state",
-	}, []string{"name", "state"})
+	}, []string{"worker_name", "state"})
 )
 
 var healthRegistry = &healthRegistryImpl{


### PR DESCRIPTION
Prometheus is doing funny things, when the pod already has a `name` label: the `name` label appears as `exported_name`,
which makes dashboards harder to write.
