### PR TITLE
add backoff health state to clear stale firing metric on retry

### DIFF
--- a/pkg/runutil/declarative.go
+++ b/pkg/runutil/declarative.go
@@ -22,7 +22,7 @@ func (w DeclarativeWorker) Run(ctx context.Context) error {
 	// Placed innermost so the full subsystem path is available.
 	inner := worker
 	worker = WorkerFunc(func(ctx context.Context) error {
-		GetHealthMonitor(ctx)
+		GetHealthMonitor(ctx).Backoff()
 		return inner.Run(ctx)
 	})
 


### PR DESCRIPTION
When a worker fails and enters retry backoff, the health gauge stayed
in "firing" even after another pod succeeded via the distributed lock.
Transition to a "backoff" state on worker restart so the stale alert
clears while the pod is waiting for its next attempt.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
