### PR TITLE
Add RetryJob for retrying jobs with backoff

### DIFF
--- a/claude/plugin/skills/rebuy-go-sdk/docs.md
+++ b/claude/plugin/skills/rebuy-go-sdk/docs.md
@@ -314,6 +314,23 @@ func (w *DataSyncWorker) Workers() []runutil.Worker {
 
 The lease gets automatically refreshed during job execution to prevent lock expiry for long-running tasks.
 
+## Retry vs RetryJob
+
+Use `runutil.RetryJob` to retry a `Job` and `runutil.Retry` to retry a `Worker`. When using `DistributedRepeat`, always use `RetryJob` to wrap the job **before** passing it to `NewDistributedRepeat`. This ensures retries happen while still holding the distributed lock. Using `DeclarativeWorker.Retry` (which wraps the entire worker) with a `DistributedRepeat` is likely a bug — the lock gets released on failure and the backoff runs without holding it, allowing another instance to grab the lock during the wait.
+
+```
+// Correct: retry inside the distributed lock
+runutil.DeclarativeWorker{
+	Name: "DataSyncWorker",
+	Worker: runutil.NewDistributedRepeat(
+		w.redisClient, "data-sync-lock", 5*time.Minute,
+		runutil.RetryJob(
+			runutil.JobFunc(w.syncData),
+			runutil.ExponentialBackoff{Initial: time.Minute, Max: 5 * time.Minute},
+		),
+	),
+}
+```
 
 # Package pkg/app/handlers
 

--- a/pkg/runutil/retry.go
+++ b/pkg/runutil/retry.go
@@ -6,6 +6,29 @@ import (
 	"github.com/rebuy-de/rebuy-go-sdk/v9/pkg/logutil"
 )
 
+// RetryJob retries a Job with backoff until it succeeds or the context is
+// cancelled. Unlike Retry, this wraps a single-execution Job and returns nil
+// on success. This is useful for retrying inside a DistributedRepeat loop
+// where the retry should happen while still holding the distributed lock.
+func RetryJob(job Job, bo Backoff) Job {
+	return JobFunc(func(ctx context.Context) error {
+		var attempt int
+		for ctx.Err() == nil {
+			err := job.RunOnce(ctx)
+			if err == nil {
+				return nil
+			}
+
+			attempt++
+			logutil.Get(ctx).Warnf("job failed %d times: %s", attempt, err.Error())
+
+			Wait(ctx, bo.Duration(attempt))
+		}
+
+		return ctx.Err()
+	})
+}
+
 // Retry restarts a Worker forever when it exists. This happens regardless of
 // whether the worker returns an error or nil. The worker only stops with
 // restarting, when the context gets cancelled.

--- a/pkg/runutil/retry_test.go
+++ b/pkg/runutil/retry_test.go
@@ -1,0 +1,93 @@
+package runutil
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestRetryJobSucceedsFirstAttempt(t *testing.T) {
+	var calls int
+	job := RetryJob(JobFunc(func(ctx context.Context) error {
+		calls++
+		return nil
+	}), StaticBackoff{Sleep: time.Second})
+
+	err := job.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestRetryJobSucceedsAfterFailures(t *testing.T) {
+	var calls int
+	job := RetryJob(JobFunc(func(ctx context.Context) error {
+		calls++
+		if calls < 4 {
+			return fmt.Errorf("attempt %d failed", calls)
+		}
+		return nil
+	}), StaticBackoff{Sleep: time.Millisecond})
+
+	err := job.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if calls != 4 {
+		t.Fatalf("expected 4 calls, got %d", calls)
+	}
+}
+
+func TestRetryJobContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var calls int
+	job := RetryJob(JobFunc(func(ctx context.Context) error {
+		calls++
+		if calls >= 2 {
+			cancel()
+		}
+		return fmt.Errorf("always fails")
+	}), StaticBackoff{Sleep: time.Millisecond})
+
+	err := job.RunOnce(ctx)
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestRetryJobBackoffApplied(t *testing.T) {
+	var calls int
+	backoff := StaticBackoff{Sleep: 50 * time.Millisecond}
+
+	job := RetryJob(JobFunc(func(ctx context.Context) error {
+		calls++
+		if calls < 3 {
+			return fmt.Errorf("fail")
+		}
+		return nil
+	}), backoff)
+
+	start := time.Now()
+	err := job.RunOnce(context.Background())
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls)
+	}
+
+	// 2 failures = 2 backoff waits of 50ms each = ~100ms minimum
+	if elapsed < 90*time.Millisecond {
+		t.Fatalf("expected at least 90ms elapsed, got %v", elapsed)
+	}
+}


### PR DESCRIPTION
This allows retrying a Job inside a DistributedRepeat loop while still
holding the distributed lock, avoiding the scheduling issues caused by
wrapping the entire worker with Retry.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
