### PR TITLE
Stop revoking token from arg on shutdown

### DIFF
--- a/pkg/vaultutil/manager.go
+++ b/pkg/vaultutil/manager.go
@@ -90,15 +90,17 @@ func Init(ctx context.Context, params Params) (*Manager, error) {
 			WithError(errors.WithStack(err)).
 			Warnf("shutting down vault manager")
 		watcher.Stop()
-		err := client.Auth().Token().RevokeSelf("")
-		if err != nil {
-			logutil.Get(ctx).
-				WithError(errors.WithStack(err)).
-				Errorf("revoking own token failed")
-		} else {
-			logutil.Get(ctx).
-				WithError(errors.WithStack(err)).
-				Debugf("revoking own token succeeded")
+		if params.Token == "" {
+			err := client.Auth().Token().RevokeSelf("")
+			if err != nil {
+				logutil.Get(ctx).
+					WithError(errors.WithStack(err)).
+					Errorf("revoking own token failed")
+			} else {
+				logutil.Get(ctx).
+					WithError(errors.WithStack(err)).
+					Debugf("revoking own token succeeded")
+			}
 		}
 	}()
 


### PR DESCRIPTION
I was trying to use a tool with Vault secrets locally with a token acquired via `vault login`, however I had to re-login after every attempt because my token was revoked on shutdown. We should only do this on k8s I think.