### PR TITLE
Expand riverutil docs with tracer provider setup and stale-job skip

### DIFF
--- a/claude/plugin/skills/apply-sdk-migrations/migrations/v10/M0010-riverutil-periodic-jobs.md
+++ b/claude/plugin/skills/apply-sdk-migrations/migrations/v10/M0010-riverutil-periodic-jobs.md
@@ -87,3 +87,51 @@ riverutil.Provide(c, river_workers.NewDataSync),
 ```
 
 River retries failed jobs automatically with exponential backoff, so the explicit `RetryJob` wrapper is not needed.
+
+## Tracer provider setup
+
+`riverutil.NewRiverClient` pulls `*ddotel.TracerProvider` from the dig container and skips tracing when none is provided. To get River traces in DataDog, build the provider in the DaemonRunner and register it.
+
+Older projects typically initialize the tracer in two steps and never register a provider:
+
+```go
+tracer.Start(
+	tracer.WithEnv("production"),
+	tracer.WithService(cmdutil.Name),
+	tracer.WithUDS("/var/run/datadog/apm.socket"),
+)
+defer tracer.Stop()
+
+tracerProvider := ddotel.NewTracerProvider()
+digutil.ProvideValue(c, tracerProvider)
+```
+
+`ddotel.NewTracerProvider` already calls `tracer.Start` internally, so the separate `tracer.Start` / `tracer.Stop` pair is redundant. Collapse to a single call, pass the tracer options to the provider, and shut the provider down on exit:
+
+```go
+provider := ddotel.NewTracerProvider(
+	tracer.WithEnv("production"),
+	tracer.WithService(cmdutil.Name),
+	tracer.WithUDS("/var/run/datadog/apm.socket"),
+)
+defer func() { _ = provider.Shutdown() }()
+
+digutil.ProvideValue[*ddotel.TracerProvider](c, provider)
+```
+
+Use the explicit type parameter on `digutil.ProvideValue` — it documents the dig type at the call site and matches the `digutil.ProvideValue[*ddotel.TracerProvider](c, nil)` pattern used in the `DevRunner` to opt out of tracing locally.
+
+## Skipping stale jobs
+
+Periodic jobs can back up if the worker is slow or the service was down. The job's `ScheduledAt` then trails real time, and running it would produce stale work. Cancel the job at the top of `Work` instead of executing it:
+
+```go
+func (w *DataSync) Work(ctx context.Context, job *river.Job[DataSyncArgs]) error {
+	if time.Since(job.JobRow.ScheduledAt) > 5*time.Minute {
+		return river.JobCancel(fmt.Errorf("skipping stale job"))
+	}
+	return pgutil.Tx(ctx, w.pool, w.syncData)
+}
+```
+
+Apply this guard only to periodic workers. Workers triggered by `riverutil.Insert` from a handler or another worker must run the work regardless of age — the enqueueing caller, not the wall clock, decides whether the job is still relevant.

--- a/claude/plugin/skills/rebuy-go-sdk/docs.md
+++ b/claude/plugin/skills/rebuy-go-sdk/docs.md
@@ -639,6 +639,21 @@ err := errors.Join(
 
 `NewRiverClient` pulls `*pgxpool.Pool`, `*ddotel.TracerProvider`, and the `river_configer` dig group from the container. Tracing is skipped when no `TracerProvider` is provided.
 
+The provider is built in the `DaemonRunner` (the production runner in `cmd/root.go`) and registered into dig in a single step. `ddotel.NewTracerProvider` calls `tracer.Start` internally, so do not also call `tracer.Start` / `tracer.Stop` separately — pass the tracer options to the provider and shut it down on exit:
+
+```go
+provider := ddotel.NewTracerProvider(
+	tracer.WithEnv("production"),
+	tracer.WithService(cmdutil.Name),
+	tracer.WithUDS("/var/run/datadog/apm.socket"),
+)
+defer func() { _ = provider.Shutdown() }()
+
+digutil.ProvideValue[*ddotel.TracerProvider](c, provider)
+```
+
+Use the explicit type parameter on `digutil.ProvideValue` so the dig type is visible at the call site. The `DevRunner` mirrors the same shape but opts out of tracing with `digutil.ProvideValue[*ddotel.TracerProvider](c, nil)`, which `NewRiverClient` treats as "tracing disabled".
+
 ## Defining Workers
 
 Workers live in `./pkg/app/river_workers`, one per file (matching the convention for in-process workers). Each worker defines an args struct with a `Kind()` method, embeds `river.WorkerDefaults` for default lifecycle hooks, registers itself in `Config(*river.Config) error`, and implements `Work`:


### PR DESCRIPTION
Adopting River pulls in two patterns that projects regularly get wrong on
first wire-up: building the ddotel tracer provider in a single step
(instead of the older tracer.Start / tracer.Stop pair plus a bare
NewTracerProvider), and guarding periodic Work methods against stale
ScheduledAt. Document both in the M0010 migration so they're picked up
at adoption time, and mirror the tracer guidance in the riverutil
reference so it's discoverable later.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
