### PR TITLE
Tolerate missing git repo in buildutil

### DIFF
--- a/cmd/buildutil/chain.go
+++ b/cmd/buildutil/chain.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"os/exec"
 	"strconv"
@@ -10,6 +11,16 @@ import (
 
 	"github.com/rebuy-de/rebuy-go-sdk/v10/pkg/executil"
 )
+
+// IsGitAvailable reports whether `git` is on PATH and the current working
+// directory is inside a git work tree. Stderr is suppressed so the probe is
+// silent in non-repo environments.
+func IsGitAvailable(ctx context.Context) bool {
+	c := exec.CommandContext(ctx, "git", "rev-parse", "--git-dir")
+	c.Stdout = io.Discard
+	c.Stderr = io.Discard
+	return c.Run() == nil
+}
 
 type ChainExecutor struct {
 	ctx context.Context

--- a/cmd/buildutil/info.go
+++ b/cmd/buildutil/info.go
@@ -253,9 +253,6 @@ func CollectBuildInformation(ctx context.Context, p BuildParameters) (BuildInfo,
 	info.System.OS = e.OutputString(p.GoCommand, "env", "GOOS")
 	info.System.Arch = e.OutputString(p.GoCommand, "env", "GOARCH")
 	info.System.Ext = e.OutputString(p.GoCommand, "env", "GOEXE")
-	info.Commit.Date = time.Unix(e.OutputInt64("git", "show", "-s", "--format=%ct"), 0).Format(time.RFC3339)
-	info.Commit.Hash = e.OutputString("git", "rev-parse", "HEAD")
-	info.Commit.Branch = e.OutputString("git", "rev-parse", "--abbrev-ref", "HEAD")
 	info.Go.Work = e.OutputString(p.GoCommand, "env", "GOWORK")
 
 	info.SDKVersion, err = ParseVersion(e.OutputString(p.GoCommand, "list", "-mod=readonly", "-m", "-f", "{{.Version}}", "github.com/rebuy-de/rebuy-go-sdk/..."))
@@ -263,9 +260,31 @@ func CollectBuildInformation(ctx context.Context, p BuildParameters) (BuildInfo,
 		slog.Error("Failed to parse sdk-version", "error", err)
 	}
 
-	info.Version, err = ParseVersion(e.OutputString("git", "describe", "--always", "--dirty", "--tags"))
-	if err != nil {
-		slog.Error("Failed to parse version", "error", err)
+	if IsGitAvailable(ctx) {
+		if ts := e.OutputInt64("git", "show", "-s", "--format=%ct"); ts != 0 {
+			info.Commit.Date = time.Unix(ts, 0).Format(time.RFC3339)
+		}
+		info.Commit.Hash = e.OutputString("git", "rev-parse", "HEAD")
+		info.Commit.Branch = e.OutputString("git", "rev-parse", "--abbrev-ref", "HEAD")
+
+		info.Version, err = ParseVersion(e.OutputString("git", "describe", "--always", "--dirty", "--tags"))
+		if err != nil {
+			slog.Error("Failed to parse version", "error", err)
+		}
+
+		status := strings.TrimSpace(e.OutputString("git", "status", "-s"))
+		if status != "" {
+			for _, file := range strings.Split(status, "\n") {
+				info.Commit.DirtyFiles = append(info.Commit.DirtyFiles, strings.TrimSpace(file))
+			}
+		}
+	} else {
+		// No .git directory or no git binary on PATH. Build can still
+		// proceed, but commit metadata is unavailable.
+		slog.Warn("No git repository detected; building without commit info")
+		// Kind is left empty so Version.String() renders as "v0.0.0+unknown"
+		// instead of "v0.0.0+unknown.unknown".
+		info.Version = Version{Suffix: "unknown"}
 	}
 
 	goVersionMatch := regexp.MustCompile(`(?m)go(\d.*) `).FindStringSubmatch(e.OutputString(p.GoCommand, "version"))
@@ -273,13 +292,6 @@ func CollectBuildInformation(ctx context.Context, p BuildParameters) (BuildInfo,
 		info.Go.Version = "unknown version"
 	} else {
 		info.Go.Version = goVersionMatch[1]
-	}
-
-	status := strings.TrimSpace(e.OutputString("git", "status", "-s"))
-	if status != "" {
-		for _, file := range strings.Split(status, "\n") {
-			info.Commit.DirtyFiles = append(info.Commit.DirtyFiles, strings.TrimSpace(file))
-		}
 	}
 
 	nameMatch := regexp.MustCompile(`([^/]+)(/v\d+)?$`).FindStringSubmatch(info.Go.Module)

--- a/cmd/buildutil/info_test.go
+++ b/cmd/buildutil/info_test.go
@@ -1,6 +1,33 @@
 package main
 
-import "testing"
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestIsGitAvailable(t *testing.T) {
+	ctx := context.Background()
+
+	if !IsGitAvailable(ctx) {
+		t.Fatal("expected git to be available in repo cwd")
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(cwd) })
+
+	err = os.Chdir(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if IsGitAvailable(ctx) {
+		t.Fatal("expected git to be unavailable in non-repo tempdir")
+	}
+}
 
 func TestParseVersion(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## Motivation

`buildutil` aborts before any compilation when run outside a git work tree (e.g. tarball extracts, slim containers) or on a host without the `git` binary, because all five `git` shellouts in `CollectBuildInformation` go through `ChainExecutor` which short-circuits on the first error.

## Outcome

A build without git metadata now succeeds. The user sees a single warning ("No git repository detected; building without commit info"), the commit fields stay empty, and the produced version renders as `v0.0.0+unknown`. When git *is* available, behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)