### PR TITLE
Tolerate ClickHouse startup connection failures

### DIFF
--- a/pkg/chutil/dig.go
+++ b/pkg/chutil/dig.go
@@ -1,6 +1,8 @@
 package chutil
 
 import (
+	"log/slog"
+
 	"github.com/rebuy-de/rebuy-go-sdk/v10/pkg/runutil"
 	"go.uber.org/dig"
 )
@@ -10,15 +12,30 @@ import (
 // register the address and credentials with digutil.ProvideValue beforehand;
 // the worker registration no longer has to be done by the application.
 //
+// On open failure Provide logs a warning and provides a nil *Batcher instead of
+// returning an error, so an unreachable ClickHouse never blocks server startup.
+// Consumers that nil-guard the batcher skip analytics silently; the worker loop
+// is also skipped.
+//
 // A generic function cannot be passed to dig.Provide directly; this helper pins
 // the concrete row type T inside a closure.
 func Provide[T any](c *dig.Container, insertSQL string, opts ...Option) error {
-	err := c.Provide(func(addr Addr, auth Auth) (*Batcher[T], error) {
-		return New[T](addr, auth, insertSQL, opts...)
+	err := c.Provide(func(addr Addr, auth Auth) *Batcher[T] {
+		b, err := New[T](addr, auth, insertSQL, opts...)
+		if err != nil {
+			slog.Warn("disabling clickhouse analytics: open connection failed", "error", err)
+			return nil
+		}
+		return b
 	})
 	if err != nil {
 		return err
 	}
 
-	return runutil.ProvideWorker(c, func(b *Batcher[T]) *Batcher[T] { return b })
+	return c.Provide(func(b *Batcher[T]) runutil.WorkerConfiger {
+		if b == nil {
+			return nil
+		}
+		return b
+	}, dig.Group("worker"))
 }

--- a/pkg/chutil/doc.go
+++ b/pkg/chutil/doc.go
@@ -11,7 +11,9 @@
 //
 // To wire it into a dig container, register the address and credentials, then
 // provide the batcher with Provide. Provide also registers the batcher as a
-// worker, so its Run loop executes without any extra wiring:
+// worker, so its Run loop executes without any extra wiring. If ClickHouse is
+// unreachable at startup, Provide logs a warning and supplies a nil *Batcher
+// rather than returning an error, so the server starts regardless:
 //
 //	digutil.ProvideValue[chutil.Addr](c, "clickhouse:9000")
 //	digutil.ProvideValue(c, auth) // chutil.Auth, e.g. from vaultutil.DecodeSecret


### PR DESCRIPTION
An unreachable ClickHouse at startup currently fails the whole server boot. This makes analytics best-effort: if the connection can't be opened, `chutil.Provide` logs a warning and supplies a nil `*Batcher` (skipping the worker loop) instead of returning an error, so the server starts regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)