### PR TITLE
Add ClickHouse schema migrations

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/ClickHouse/ch-go v0.71.0 h1:bUdZ/EZj/LcVHsMqaRUP2holqygrPWQKeMjc6nZoyRM=
 github.com/ClickHouse/ch-go v0.71.0/go.mod h1:NwbNc+7jaqfY58dmdDUbG4Jl22vThgx1cYjBw0vtgXw=
+github.com/ClickHouse/clickhouse-go v1.4.3 h1:iAFMa2UrQdR5bHJ2/yaSLffZkxpcOYQMCUuKeNXGdqc=
+github.com/ClickHouse/clickhouse-go v1.4.3/go.mod h1:EaI/sW7Azgz9UATzd5ZdZHRUhHgv5+JMS9NSr2smCJI=
 github.com/ClickHouse/clickhouse-go/v2 v2.46.0 h1:s3eRy+hYmu5uzotB6ZhDofgHu8kDgGN/fpmjxRkqSpk=
 github.com/ClickHouse/clickhouse-go/v2 v2.46.0/go.mod h1:giJfUVlMkcfUEPVfRpt51zZaGEx9i17gCos8gBl392c=
 github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.77.0 h1:Lu/HEo5svx/UwE7XWh8vOrEHCrVRsein9X1N0jGK5bo=
@@ -151,6 +153,8 @@ github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 h1:kHaBemcxl8o/pQ5VM1
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
+github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58 h1:F1EaeKL/ta07PY/k9Os/UFtwERei2/XzGemhpGnBKNg=
+github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=

--- a/pkg/chutil/doc.go
+++ b/pkg/chutil/doc.go
@@ -18,4 +18,21 @@
 //	digutil.ProvideValue[chutil.Addr](c, "clickhouse:9000")
 //	digutil.ProvideValue(c, auth) // chutil.Auth, e.g. from vaultutil.DecodeSecret
 //	chutil.Provide[Row](c, "INSERT INTO db.table (col_a, col_b)")
+//	runutil.ProvideWorker(c, func(b *chutil.Batcher[Row]) *chutil.Batcher[Row] { return b })
+//
+// # Migrations
+//
+// Migrate manages the ClickHouse schema, mirroring pgutil.Migrate. It creates
+// the database named in Auth.Database (ClickHouse's namespace, analogous to a
+// Postgres schema), runs versioned `*.up.sql` migrations via golang-migrate,
+// then applies repeatable `R_*.sql` migrations tracked by content hash. Both
+// kinds live under a top-level "migrations" directory in the embedded FS. Reuse
+// the Addr and Auth already registered for the Batcher and invoke it directly:
+//
+//	digutil.ProvideValue[chutil.MigrationFS](c, chutil.MigrationFS(migrationsFS))
+//	c.Invoke(chutil.Migrate)
+//
+// ClickHouse has no DDL transactions and the std driver runs one statement per
+// call, so each R_*.sql file must contain a single statement, typically a
+// `CREATE OR REPLACE VIEW`.
 package chutil

--- a/pkg/chutil/migration.go
+++ b/pkg/chutil/migration.go
@@ -1,0 +1,122 @@
+package chutil
+
+import (
+	"context"
+	"database/sql"
+	"embed"
+	"errors"
+	"fmt"
+	"strings"
+
+	chgo "github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/golang-migrate/migrate/v4"
+	chmigrate "github.com/golang-migrate/migrate/v4/database/clickhouse"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+)
+
+// migrationsDir is the top-level directory inside a MigrationFS that holds both
+// versioned (`*.up.sql`) and repeatable (`R_*.sql`) migration files.
+const migrationsDir = "migrations"
+
+// MigrationFS is an embedded filesystem containing migration files, for
+// dependency injection. It is the ClickHouse counterpart of pgutil.MigrationFS.
+type MigrationFS embed.FS
+
+// Migrate applies database migrations to ClickHouse. It is the counterpart of
+// pgutil.Migrate, adapted to ClickHouse semantics: it creates the target
+// database (ClickHouse's namespace, analogous to a Postgres schema) if missing,
+// runs versioned migrations via golang-migrate, then applies repeatable
+// (R_*.sql) migrations. The database name is taken from auth.Database.
+//
+// Migrations run over a database/sql connection (clickhouse-go's std driver),
+// not the native batcher connection, because golang-migrate needs a *sql.DB.
+func Migrate(ctx context.Context, addr Addr, auth Auth, migrationsFS MigrationFS) error {
+	// The target database may not exist yet, so bootstrap on the default
+	// database to create it before opening a connection scoped to it.
+	bootstrap := openMigrationDB(addr, auth, "")
+	defer bootstrap.Close()
+
+	err := createDatabaseIfNotExists(ctx, bootstrap, auth.Database)
+	if err != nil {
+		return fmt.Errorf("create database: %w", err)
+	}
+
+	db := openMigrationDB(addr, auth, auth.Database)
+	defer db.Close()
+
+	err = runNormalMigrations(db, auth.Database, embed.FS(migrationsFS))
+	if err != nil {
+		return fmt.Errorf("failed to run normal migrations: %w", err)
+	}
+
+	err = runRepeatableMigrations(ctx, db, auth.Database, embed.FS(migrationsFS))
+	if err != nil {
+		return fmt.Errorf("failed to run repeatable migrations: %w", err)
+	}
+
+	return nil
+}
+
+// openMigrationDB opens a database/sql handle scoped to the given database. An
+// empty database connects to the server's default, which is needed to create
+// the target database before it exists.
+func openMigrationDB(addr Addr, auth Auth, database string) *sql.DB {
+	return chgo.OpenDB(&chgo.Options{
+		Addr: []string{string(addr)},
+		Auth: chgo.Auth{
+			Database: database,
+			Username: auth.Username,
+			Password: auth.Password,
+		},
+		Compression: &chgo.Compression{Method: chgo.CompressionLZ4},
+	})
+}
+
+// createDatabaseIfNotExists creates the target database if it does not exist.
+func createDatabaseIfNotExists(ctx context.Context, db *sql.DB, database string) error {
+	query := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", quoteIdentifier(database))
+	_, err := db.ExecContext(ctx, query)
+	return err
+}
+
+// runNormalMigrations applies the versioned migrations using golang-migrate's
+// clickhouse driver.
+func runNormalMigrations(db *sql.DB, database string, migrationsFS embed.FS) error {
+	sourceDriver, err := iofs.New(migrationsFS, migrationsDir)
+	if err != nil {
+		return fmt.Errorf("failed to load migration source driver: %w", err)
+	}
+
+	databaseDriver, err := chmigrate.WithInstance(db, &chmigrate.Config{
+		DatabaseName:    database,
+		MigrationsTable: "schema_migrations",
+		// MergeTree replicates well; the driver appends an ORDER BY for any
+		// "*Tree" engine, so the migration-tracking table is created correctly.
+		MigrationsTableEngine: "MergeTree",
+		// Allow more than one statement per *.up.sql file, matching the
+		// multi-statement behaviour the Postgres driver provides by default.
+		MultiStatementEnabled: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to load database driver: %w", err)
+	}
+
+	m, err := migrate.NewWithInstance("iofs", sourceDriver, "clickhouse", databaseDriver)
+	if err != nil {
+		return fmt.Errorf("failed to setup migration: %w", err)
+	}
+
+	err = m.Up()
+	if err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		return fmt.Errorf("failed to run migrations: %w", err)
+	}
+
+	return nil
+}
+
+// quoteIdentifier wraps a ClickHouse identifier in backticks, escaping embedded
+// backticks, so a database or table name cannot break out of the quoting.
+// ClickHouse has no pgx.Identifier equivalent.
+func quoteIdentifier(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}

--- a/pkg/chutil/migration.go
+++ b/pkg/chutil/migration.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	chgo "github.com/ClickHouse/clickhouse-go/v2"
@@ -35,6 +36,11 @@ func Migrate(ctx context.Context, addr Addr, auth Auth, migrationsFS MigrationFS
 	// database to create it before opening a connection scoped to it.
 	bootstrap := openMigrationDB(addr, auth, "")
 	defer bootstrap.Close()
+
+	if err := bootstrap.PingContext(ctx); err != nil {
+		slog.WarnContext(ctx, "skipping clickhouse migrations: connection unavailable", "error", err)
+		return nil
+	}
 
 	err := createDatabaseIfNotExists(ctx, bootstrap, auth.Database)
 	if err != nil {

--- a/pkg/chutil/migration_test.go
+++ b/pkg/chutil/migration_test.go
@@ -1,0 +1,48 @@
+package chutil
+
+import (
+	"embed"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed testdata/migrations/*.sql
+var testMigrations embed.FS
+
+func TestFilterRepeatableSQLFiles(t *testing.T) {
+	entries, err := testMigrations.ReadDir("testdata/migrations")
+	require.NoError(t, err)
+
+	got := filterRepeatableSQLFiles(entries)
+
+	// Only the R_ prefixed .sql file is repeatable; the versioned 0001 file is
+	// left for golang-migrate to handle.
+	assert.Equal(t, []string{"R_001_events_view.sql"}, got)
+}
+
+func TestCalculateRepeatableFileHash(t *testing.T) {
+	a := calculateRepeatableFileHash([]byte("select 1"))
+	again := calculateRepeatableFileHash([]byte("select 1"))
+	different := calculateRepeatableFileHash([]byte("select 2"))
+
+	assert.Equal(t, a, again, "hash must be stable for identical content")
+	assert.NotEqual(t, a, different, "hash must change with content")
+	assert.Len(t, a, 64, "sha256 hex digest is 64 chars")
+}
+
+func TestRepeatableNeedsApply(t *testing.T) {
+	// Never applied before: must run regardless of the (empty) stored hash.
+	assert.True(t, repeatableNeedsApply("", false, "abc"))
+	// Applied, content unchanged: skip.
+	assert.False(t, repeatableNeedsApply("abc", true, "abc"))
+	// Applied, content changed: re-run.
+	assert.True(t, repeatableNeedsApply("abc", true, "def"))
+}
+
+func TestQuoteIdentifier(t *testing.T) {
+	assert.Equal(t, "`analytics`", quoteIdentifier("analytics"))
+	// Embedded backticks are doubled so a name cannot break out of the quoting.
+	assert.Equal(t, "`a``b`", quoteIdentifier("a`b"))
+}

--- a/pkg/chutil/repeatable.go
+++ b/pkg/chutil/repeatable.go
@@ -1,0 +1,158 @@
+package chutil
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"embed"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+var (
+	ErrRepeatableMigrationFailed = errors.New("repeatable migration failed")
+	ErrInvalidRepeatableFile     = errors.New("invalid repeatable file")
+)
+
+const (
+	repeatableSQLExtension    = ".sql"
+	repeatablePrefix          = "R_"
+	repeatableMigrationsTable = "schema_migrations_repeatable"
+)
+
+// runRepeatableMigrations processes all SQL files with prefix 'R_' in the
+// embedded filesystem and applies them to ClickHouse. It tracks applied files in
+// a schema_migrations_repeatable table and only re-applies files that are new or
+// whose content hash has changed.
+//
+// Unlike the Postgres counterpart in pgutil, each R_*.sql file must contain a
+// single statement: ClickHouse has no multi-statement transactions and the std
+// driver's ExecContext runs one statement per call. A single
+// `CREATE OR REPLACE VIEW`, which ClickHouse supports, is the common case.
+func runRepeatableMigrations(ctx context.Context, db *sql.DB, database string, fsys embed.FS) error {
+	err := initRepeatableMigrationsTable(ctx, db, database)
+	if err != nil {
+		return fmt.Errorf("failed to initialize repeatable migrations table: %w", err)
+	}
+
+	entries, err := fsys.ReadDir(migrationsDir)
+	if err != nil {
+		return fmt.Errorf("failed to read embedded files: %w", err)
+	}
+
+	filenames := filterRepeatableSQLFiles(entries)
+	sort.Strings(filenames)
+
+	for _, filename := range filenames {
+		err := applyRepeatableMigration(ctx, db, database, fsys, filename)
+		if err != nil {
+			return fmt.Errorf("%w: %s: %v", ErrRepeatableMigrationFailed, filename, err)
+		}
+	}
+
+	return nil
+}
+
+func filterRepeatableSQLFiles(entries []fs.DirEntry) []string {
+	filenames := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if !entry.IsDir() &&
+			filepath.Ext(name) == repeatableSQLExtension &&
+			strings.HasPrefix(name, repeatablePrefix) {
+			filenames = append(filenames, name)
+		}
+	}
+	return filenames
+}
+
+// initRepeatableMigrationsTable creates the tracking table. ClickHouse has no
+// primary-key uniqueness, so a ReplacingMergeTree ordered by filename collapses
+// to the newest row per file (highest executed_at), which is read back with
+// FINAL in applyRepeatableMigration.
+func initRepeatableMigrationsTable(ctx context.Context, db *sql.DB, database string) error {
+	query := fmt.Sprintf(`
+        CREATE TABLE IF NOT EXISTS %s.%s (
+            filename    String,
+            hash        String,
+            executed_at DateTime DEFAULT now()
+        ) ENGINE = ReplacingMergeTree(executed_at)
+        ORDER BY filename`, quoteIdentifier(database), repeatableMigrationsTable)
+
+	_, err := db.ExecContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to create repeatable migrations table in database %s: %w", database, err)
+	}
+	return nil
+}
+
+// repeatableNeedsApply reports whether a repeatable file must run: either it was
+// never applied (found is false) or its content hash has changed since the last
+// run.
+func repeatableNeedsApply(storedHash string, found bool, newHash string) bool {
+	return !found || storedHash != newHash
+}
+
+func calculateRepeatableFileHash(content []byte) string {
+	hasher := sha256.New()
+	hasher.Write(content)
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+func applyRepeatableMigration(ctx context.Context, db *sql.DB, database string, fsys embed.FS, filename string) error {
+	filePath := path.Join(migrationsDir, filename)
+	content, err := fsys.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("%w: failed to read repeatable migration file %s: %v", ErrInvalidRepeatableFile, filePath, err)
+	}
+
+	hash := calculateRepeatableFileHash(content)
+
+	// FINAL forces ReplacingMergeTree to resolve to the newest row for the file,
+	// so we compare against the last-applied hash even before a background merge.
+	var storedHash string
+	query := fmt.Sprintf("SELECT hash FROM %s.%s FINAL WHERE filename = ?",
+		quoteIdentifier(database), repeatableMigrationsTable)
+	err = db.QueryRowContext(ctx, query, filename).Scan(&storedHash)
+
+	found := true
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		found = false
+	case err != nil:
+		return fmt.Errorf("failed to query repeatable migration status for %s in database %s: %w", filename, database, err)
+	}
+
+	if !repeatableNeedsApply(storedHash, found, hash) {
+		// Already applied and unchanged; skip.
+		return nil
+	}
+
+	return executeRepeatableMigration(ctx, db, database, filename, string(content), hash)
+}
+
+// executeRepeatableMigration runs the migration body and records its hash. There
+// is no surrounding transaction (ClickHouse does not support DDL transactions),
+// and the tracking insert relies on the ReplacingMergeTree to supersede any
+// previous hash for the same filename rather than an upsert.
+func executeRepeatableMigration(ctx context.Context, db *sql.DB, database, filename, content, hash string) error {
+	_, err := db.ExecContext(ctx, content)
+	if err != nil {
+		return fmt.Errorf("failed to execute repeatable migration %s: %w", filename, err)
+	}
+
+	insert := fmt.Sprintf("INSERT INTO %s.%s (filename, hash) VALUES (?, ?)",
+		quoteIdentifier(database), repeatableMigrationsTable)
+	_, err = db.ExecContext(ctx, insert, filename, hash)
+	if err != nil {
+		return fmt.Errorf("failed to update repeatable migration tracking record for %s in database %s: %w", filename, database, err)
+	}
+
+	return nil
+}

--- a/pkg/chutil/testdata/migrations/0001_initial.up.sql
+++ b/pkg/chutil/testdata/migrations/0001_initial.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS events (
+    id    UInt64,
+    name  String,
+    ts    DateTime
+) ENGINE = MergeTree
+ORDER BY (ts, id);

--- a/pkg/chutil/testdata/migrations/R_001_events_view.sql
+++ b/pkg/chutil/testdata/migrations/R_001_events_view.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE VIEW events_by_name AS
+SELECT name, count() AS total
+FROM events
+GROUP BY name


### PR DESCRIPTION
Mirror pgutil.Migrate for ClickHouse: create the target database, run
versioned *.up.sql migrations via golang-migrate's clickhouse driver, then
apply hash-tracked repeatable R_*.sql migrations. Adapted to ClickHouse
semantics (database namespace, ReplacingMergeTree tracking, no DDL
transactions, single-statement repeatables).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
