### PR TITLE
Remove `--s3-url` from buildutil as it has no function

### DIFF
--- a/cmd/buildutil/info.go
+++ b/cmd/buildutil/info.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"net/url"
 	"os"
 	"path"
 	"regexp"
@@ -13,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/rebuy-de/rebuy-go-sdk/v10/pkg/cmdutil"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/tools/go/packages"
@@ -173,11 +171,10 @@ type BuildInfo struct {
 }
 
 type ArtifactInfo struct {
-	Kind       string
-	Filename   string
-	S3Location *S3URL   `json:",omitempty"`
-	Aliases    []string `json:",omitempty"`
-	System     SystemInfo
+	Kind     string
+	Filename string
+	Aliases  []string `json:",omitempty"`
+	System   SystemInfo
 }
 
 func (i *BuildInfo) NewArtifactInfo(kind string, name string, system SystemInfo, ext string) ArtifactInfo {
@@ -407,53 +404,5 @@ func CollectBuildInformation(ctx context.Context, p BuildParameters) (BuildInfo,
 		}
 	}
 
-	if p.S3URL != "" {
-		base, err := ParseS3URL(p.S3URL)
-		if err != nil {
-			return info, errors.WithStack(err)
-		}
-
-		for i, a := range info.Artifacts {
-			u := base.Subpath(a.Filename)
-			info.Artifacts[i].S3Location = &u
-		}
-	}
-
 	return info, nil
-}
-
-type S3URL struct {
-	Bucket string
-	Key    string
-}
-
-func ParseS3URL(raw string) (*S3URL, error) {
-	u, err := url.Parse(raw)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse S3 URL")
-	}
-
-	if u.Scheme != "s3" && u.Scheme != "" {
-		return nil, errors.Errorf("Unknown scheme %s for the S3 URL", u.Scheme)
-	}
-
-	return &S3URL{
-		Bucket: u.Host,
-		Key:    strings.TrimPrefix(path.Clean(u.Path), "/"),
-	}, nil
-}
-
-func (u S3URL) Subpath(p ...string) S3URL {
-	p = append([]string{u.Key}, p...)
-	u.Key = path.Join(p...)
-	return u // This is actually a copy, since we do not use pointers.
-}
-
-func (u S3URL) String() string {
-	return fmt.Sprintf("s3://%s/%s", u.Bucket, u.Key)
-}
-
-func (u S3URL) MarshalJSON() ([]byte, error) {
-	s := u.String()
-	return json.Marshal(s)
 }

--- a/cmd/buildutil/runner.go
+++ b/cmd/buildutil/runner.go
@@ -26,7 +26,6 @@ func call(ctx context.Context, command string, args ...string) error {
 type BuildParameters struct {
 	TargetSystems  []string
 	TargetPackages []string
-	S3URL          string
 
 	CreateCompressed bool
 	CreateRPM        bool
@@ -53,9 +52,6 @@ func (r *Runner) Bind(cmd *cobra.Command) error {
 	cmd.PersistentFlags().StringSliceVarP(
 		&r.Parameters.TargetPackages, "package", "p", []string{},
 		"Packages to build.")
-	cmd.PersistentFlags().StringVar(
-		&r.Parameters.S3URL, "s3-url", "",
-		"S3 URL to upload compiled releases.")
 
 	cmd.PersistentFlags().BoolVar(
 		&r.Parameters.CreateCompressed, "compress", false,


### PR DESCRIPTION
The upload was removed a while ago, but the `--s3-url` arg was missed, so it wasn't doing anything the last ~2 years.