### PR TITLE
Remove `--rpm`, `--deb` and `--compressed` from buildutil as well

### DIFF
--- a/cmd/buildutil/info.go
+++ b/cmd/buildutil/info.go
@@ -379,30 +379,5 @@ func CollectBuildInformation(ctx context.Context, p BuildParameters) (BuildInfo,
 		info.Test.Files = append(info.Test.Files, pkg.GoFiles...)
 	}
 
-	for _, targetSystem := range targetSystems {
-		if targetSystem.OS == "windows" && p.CreateCompressed {
-			info.Artifacts = append(info.Artifacts, info.NewArtifactInfo(
-				"zip", info.Go.Name, targetSystem, ".zip"))
-		}
-
-		if targetSystem.OS != "windows" && p.CreateCompressed {
-			if p.CreateCompressed {
-				info.Artifacts = append(info.Artifacts, info.NewArtifactInfo(
-					"tgz", info.Go.Name, targetSystem, ".tar.gz"))
-			}
-		}
-
-		if targetSystem.OS == "linux" {
-			if p.CreateDEB {
-				info.Artifacts = append(info.Artifacts, info.NewArtifactInfo(
-					"deb", info.Go.Name, targetSystem, ".deb"))
-			}
-			if p.CreateRPM {
-				info.Artifacts = append(info.Artifacts, info.NewArtifactInfo(
-					"rpm", info.Go.Name, targetSystem, ".rpm"))
-			}
-		}
-	}
-
 	return info, nil
 }

--- a/cmd/buildutil/runner.go
+++ b/cmd/buildutil/runner.go
@@ -27,10 +27,6 @@ type BuildParameters struct {
 	TargetSystems  []string
 	TargetPackages []string
 
-	CreateCompressed bool
-	CreateRPM        bool
-	CreateDEB        bool
-
 	GoCommand string
 
 	CGO bool
@@ -53,15 +49,6 @@ func (r *Runner) Bind(cmd *cobra.Command) error {
 		&r.Parameters.TargetPackages, "package", "p", []string{},
 		"Packages to build.")
 
-	cmd.PersistentFlags().BoolVar(
-		&r.Parameters.CreateCompressed, "compress", false,
-		"Creates .tgz artifacts for POSIX targets and .zip for windows.")
-	cmd.PersistentFlags().BoolVar(
-		&r.Parameters.CreateRPM, "rpm", false,
-		"Creates .rpm artifacts for linux targets.")
-	cmd.PersistentFlags().BoolVar(
-		&r.Parameters.CreateDEB, "deb", false,
-		"Creates .deb artifacts for linux targets.")
 	cmd.PersistentFlags().BoolVar(
 		&r.Parameters.CGO, "cgo", false,
 		"Enable CGO.")


### PR DESCRIPTION
Same as #325, leftovers in code without any function.